### PR TITLE
Osprey Tuneup + Wholesale Ship Missing Path Fix

### DIFF
--- a/_maps/voidcrew/ship_bogatyr.dmm
+++ b/_maps/voidcrew/ship_bogatyr.dmm
@@ -79,6 +79,7 @@
 	desc = "A box containing a gift for worthy russians.";
 	name = "\proper russian science program"
 	},
+/obj/structure/cable,
 /turf/open/floor/mineral/titanium/purple,
 /area/station/science)
 "dH" = (
@@ -112,7 +113,6 @@
 /obj/item/storage/toolbox/mechanical{
 	pixel_x = -1
 	},
-/obj/item/clothing/head/welding,
 /obj/item/clothing/under/rank/engineering/engineer,
 /obj/item/clothing/gloves/color/yellow,
 /obj/effect/decal/cleanable/dirt,
@@ -120,6 +120,7 @@
 /obj/item/stack/cable_coil,
 /obj/machinery/power/terminal,
 /obj/structure/cable,
+/obj/item/clothing/head/utility/welding,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "fa" = (
@@ -180,11 +181,17 @@
 "iN" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/central)
+"jm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/mineral/plastitanium/red,
+/area/station/maintenance/central)
 "jT" = (
-/obj/machinery/power/shuttle_engine/electric{
+/obj/structure/cable,
+/obj/machinery/power/shuttle_engine/ship/electric{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "kh" = (
@@ -202,6 +209,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/mineral/titanium/purple,
 /area/station/science)
 "lJ" = (
@@ -305,6 +313,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
+"pX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/mineral/titanium/purple,
+/area/station/science)
 "qo" = (
 /turf/closed/wall/r_wall,
 /area/station/command/bridge)
@@ -553,6 +568,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/mineral/plastitanium/red,
 /area/station/maintenance/central)
 "AH" = (
@@ -631,6 +647,7 @@
 /obj/item/gun/ballistic/revolver/russian,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/mineral/plastitanium,
 /area/station/maintenance/central)
 "Dk" = (
@@ -923,6 +940,7 @@
 /obj/effect/decal/cleanable/blood/gibs/up,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm/directional/north,
+/obj/structure/cable,
 /turf/open/floor/mineral/titanium/purple,
 /area/station/science)
 "PC" = (
@@ -1091,6 +1109,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/mineral/titanium/blue,
 /area/station/medical)
 "WR" = (
@@ -1117,13 +1136,13 @@
 /obj/structure/closet{
 	name = "mastercraft traditional russian clothes"
 	},
-/obj/item/clothing/head/ushanka,
-/obj/item/clothing/head/ushanka,
-/obj/item/clothing/head/ushanka,
 /obj/item/clothing/under/pants/track,
 /obj/item/clothing/under/pants/track,
 /obj/item/clothing/under/pants/track,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/head/costume/ushanka,
+/obj/item/clothing/head/costume/ushanka,
+/obj/item/clothing/head/costume/ushanka,
 /turf/open/floor/mineral/plastitanium,
 /area/station/commons/dorms)
 "XL" = (
@@ -1137,6 +1156,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/item/radio/intercom/directional/north,
+/obj/structure/cable,
 /turf/open/floor/mineral/titanium/purple,
 /area/station/science)
 "YI" = (
@@ -1144,6 +1164,7 @@
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/mineral/plastitanium,
 /area/station/commons/dorms)
 "YV" = (
@@ -1156,6 +1177,7 @@
 /area/station/maintenance/central)
 "YY" = (
 /obj/machinery/light,
+/obj/structure/cable,
 /turf/open/floor/mineral/plastitanium/red,
 /area/station/maintenance/central)
 "Zr" = (
@@ -1332,7 +1354,7 @@ AV
 mM
 rO
 aL
-rO
+jm
 bC
 EN
 By
@@ -1392,7 +1414,7 @@ Zr
 WX
 Pv
 fa
-gs
+pX
 LY
 YI
 Qr

--- a/_maps/voidcrew/ship_box.dmm
+++ b/_maps/voidcrew/ship_box.dmm
@@ -623,10 +623,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/voidcrew/box/engine)
-"ct" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/plating,
-/area/shuttle/voidcrew/box/engine)
 "cu" = (
 /obj/machinery/power/smes/engineering{
 	charge = 1e+006
@@ -694,6 +690,8 @@
 /obj/item/pickaxe/emergency,
 /obj/item/circuitboard/machine/ore_redemption,
 /obj/item/storage/box/lights/bulbs,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/shuttle/voidcrew/box/engine)
 "cB" = (
@@ -1264,6 +1262,9 @@
 /obj/structure/window/reinforced/spawner/west,
 /obj/machinery/door/window/left/directional/east,
 /obj/structure/cable,
+/obj/machinery/power/smes/engineering{
+	charge = 1e+006
+	},
 /turf/open/floor/plating,
 /area/shuttle/voidcrew/box/engine)
 "Dp" = (
@@ -1462,6 +1463,9 @@
 /obj/structure/closet/crate,
 /obj/item/circuitboard/machine/ore_redemption,
 /obj/structure/cable,
+/obj/machinery/power/terminal{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/shuttle/voidcrew/box/engine)
 "UN" = (
@@ -1728,7 +1732,7 @@ aS
 aa
 aS
 bp
-ct
+bm
 aS
 aS
 aa

--- a/_maps/voidcrew/ship_boyardee.dmm
+++ b/_maps/voidcrew/ship_boyardee.dmm
@@ -1050,12 +1050,12 @@
 /area/station/cargo/miningoffice)
 "Ap" = (
 /obj/item/storage/belt/janitor/full,
-/obj/structure/janitorialcart,
 /obj/item/watertank/janitor,
 /obj/item/mop,
 /obj/item/storage/bag/trash,
 /obj/effect/turf_decal/box,
 /obj/machinery/airalarm/directional/south,
+/obj/structure/mop_bucket/janitorialcart,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "Ar" = (
@@ -1203,10 +1203,10 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "Df" = (
-/obj/machinery/power/shuttle_engine/electric{
+/obj/structure/cable,
+/obj/machinery/power/shuttle_engine/ship/electric{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/station/maintenance/central)
 "Dg" = (
@@ -1515,8 +1515,6 @@
 /obj/item/storage/bag/ore,
 /obj/item/pickaxe/silver,
 /obj/item/pickaxe/silver,
-/obj/item/clothing/head/hardhat/orange,
-/obj/item/clothing/head/hardhat/orange,
 /obj/item/t_scanner/adv_mining_scanner/lesser,
 /obj/item/t_scanner/adv_mining_scanner/lesser,
 /obj/item/gps{
@@ -1530,6 +1528,8 @@
 	pixel_y = 7
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/clothing/head/utility/hardhat/orange,
+/obj/item/clothing/head/utility/hardhat/orange,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "JF" = (
@@ -1964,7 +1964,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "Uq" = (
-/obj/machinery/power/shuttle_engine/fueled/plasma{
+/obj/machinery/power/shuttle_engine/ship/fueled/plasma{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
@@ -2137,8 +2137,8 @@
 /turf/open/floor/iron/dark,
 /area/station/construction)
 "Zl" = (
-/obj/machinery/power/apc/five_k/directional/west,
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/commons/toilet)
 "Zz" = (

--- a/_maps/voidcrew/ship_boyardee_b.dmm
+++ b/_maps/voidcrew/ship_boyardee_b.dmm
@@ -421,8 +421,6 @@
 /obj/item/storage/bag/ore,
 /obj/item/pickaxe/silver,
 /obj/item/pickaxe/silver,
-/obj/item/clothing/head/hardhat/orange,
-/obj/item/clothing/head/hardhat/orange,
 /obj/item/t_scanner/adv_mining_scanner/lesser,
 /obj/item/t_scanner/adv_mining_scanner/lesser,
 /obj/item/gps{
@@ -436,6 +434,9 @@
 /obj/item/radio/intercom{
 	pixel_x = -27
 	},
+/obj/item/clothing/head/utility/hardhat/orange,
+/obj/item/clothing/head/utility/hardhat/orange,
+/obj/item/clothing/head/utility/hardhat/orange,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "mb" = (
@@ -996,10 +997,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance)
 "Df" = (
-/obj/machinery/power/shuttle_engine/electric{
+/obj/structure/cable,
+/obj/machinery/power/shuttle_engine/ship/electric{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/station/maintenance)
 "Dx" = (
@@ -1629,7 +1630,7 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "Uq" = (
-/obj/machinery/power/shuttle_engine/fueled/plasma{
+/obj/machinery/power/shuttle_engine/ship/fueled/plasma{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,

--- a/_maps/voidcrew/ship_delta.dmm
+++ b/_maps/voidcrew/ship_delta.dmm
@@ -201,7 +201,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/station/service/cafeteria)
 "ay" = (
-/obj/machinery/power/shuttle_engine/fueled/plasma{
+/obj/machinery/power/shuttle_engine/ship/fueled/plasma{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
@@ -304,6 +304,7 @@
 	},
 /obj/effect/decal/cleanable/blood/gibs/old,
 /obj/effect/turf_decal/tile/bar/diagonal_centre,
+/obj/item/clothing/head/hats/centhat,
 /turf/open/floor/iron,
 /area/station/service/cafeteria)
 "aL" = (
@@ -314,10 +315,10 @@
 /turf/open/floor/plating,
 /area/station/engineering)
 "aM" = (
-/obj/machinery/power/shuttle_engine/electric{
+/obj/structure/cable,
+/obj/machinery/power/shuttle_engine/ship/electric{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/station/engineering)
 "aN" = (
@@ -533,13 +534,13 @@
 /obj/item/stack/rods,
 /obj/item/stack/cable_coil,
 /turf/open/floor/plating/airless,
-/area/station/external)
+/area/station/service/cafeteria)
 "bj" = (
 /obj/structure/grille,
 /obj/item/stack/rods,
 /obj/item/shard,
 /turf/open/floor/plating/airless,
-/area/station/external)
+/area/station/service/cafeteria)
 "bk" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/bot,
@@ -583,7 +584,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
-/area/station/external)
+/area/station/service/cafeteria)
 "bq" = (
 /obj/structure/table,
 /obj/item/folder/blue{
@@ -708,14 +709,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
-/obj/item/clothing/head/welding{
-	pixel_x = -3;
-	pixel_y = 5
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/south,
+/obj/item/clothing/head/utility/welding,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
 "bF" = (
@@ -866,13 +864,10 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/obj/item/clothing/head/welding{
-	pixel_x = -2;
-	pixel_y = 1
-	},
 /obj/machinery/firealarm/directional/west{
 	dir = 4
 	},
+/obj/item/clothing/head/utility/welding,
 /turf/open/floor/plating,
 /area/station/engineering)
 "bX" = (
@@ -1039,12 +1034,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/remains/human{
 	desc = "They look like human remains, and have clearly been gnawed at."
-	},
-/obj/item/clothing/head/centhat{
-	desc = "There's a gouge through the top where something has clawed clean through it. Whoever was wearing it probably doesn't need a hat any more.";
-	name = "\improper damaged CentCom hat";
-	pixel_x = 2;
-	pixel_y = 2
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2013,7 +2002,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
-/area/station/external)
+/area/station/cargo)
 "BI" = (
 /obj/machinery/atmospherics/components/tank/plasma{
 	dir = 1
@@ -2183,7 +2172,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
-/area/station/external)
+/area/station/cargo)
 "Zl" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,

--- a/_maps/voidcrew/ship_dwayne.dmm
+++ b/_maps/voidcrew/ship_dwayne.dmm
@@ -8,12 +8,12 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "aD" = (
-/obj/machinery/power/shuttle_engine/electric{
+/obj/structure/cable,
+/obj/machinery/power/shuttle_engine/ship/electric{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plating/airless,
-/area/station/external)
+/area/station/engineering)
 "aI" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -149,8 +149,7 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "fy" = (
-/turf/open/floor/catwalk_floor,
-/area/station/external)
+/turf/open/floor/catwalk_floor)
 "fV" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "mining_ship_blast"
@@ -199,11 +198,11 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering)
 "gF" = (
-/obj/machinery/power/shuttle_engine/fueled/plasma{
+/obj/machinery/power/shuttle_engine/ship/fueled/plasma{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/station/external)
+/area/station/engineering)
 "he" = (
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
@@ -422,7 +421,7 @@
 	},
 /obj/effect/turf_decal/stripes,
 /turf/open/floor/plating/airless,
-/area/station/external)
+/area/station/commons)
 "lp" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/electrical{
@@ -433,10 +432,6 @@
 	pixel_x = -2;
 	pixel_y = -1
 	},
-/obj/item/clothing/head/welding{
-	pixel_x = -2;
-	pixel_y = 1
-	},
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /obj/item/clothing/gloves/color/yellow,
@@ -444,6 +439,7 @@
 /obj/item/reagent_containers/cup/beaker{
 	list_reagents = list(/datum/reagent/fuel=50)
 	},
+/obj/item/clothing/head/utility/welding,
 /turf/open/floor/iron/dark,
 /area/station/engineering)
 "ls" = (
@@ -691,15 +687,6 @@
 	pixel_x = 4;
 	pixel_y = 4
 	},
-/obj/item/clothing/head/hardhat/orange{
-	pixel_x = -4;
-	pixel_y = -4
-	},
-/obj/item/clothing/head/hardhat/orange,
-/obj/item/clothing/head/hardhat/orange{
-	pixel_x = 4;
-	pixel_y = 4
-	},
 /obj/item/gps/mining,
 /obj/item/gps/mining,
 /obj/item/gps/mining,
@@ -711,6 +698,9 @@
 /obj/item/pickaxe/silver,
 /obj/item/storage/bag/ore,
 /obj/item/storage/bag/ore,
+/obj/item/clothing/head/utility/hardhat/weldhat/orange,
+/obj/item/clothing/head/utility/hardhat/weldhat/orange,
+/obj/item/clothing/head/utility/hardhat/weldhat/orange,
 /turf/closed/wall/r_wall,
 /area/station/cargo/miningoffice)
 "tH" = (
@@ -875,11 +865,11 @@
 /turf/open/floor/plating/airless,
 /area/station/medical)
 "zq" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
-/area/station/external)
+/area/space)
 "zF" = (
 /obj/structure/cable,
 /mob/living/simple_animal/sloth/paperwork,
@@ -932,9 +922,9 @@
 /obj/item/clothing/suit/hazardvest,
 /obj/item/clothing/suit/hazardvest,
 /obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/head/cowboy_hat_brown,
-/obj/item/clothing/head/cowboy_hat_brown,
-/obj/item/clothing/head/cowboy_hat_brown,
+/obj/item/clothing/head/cowboy/brown,
+/obj/item/clothing/head/cowboy/brown,
+/obj/item/clothing/head/cowboy/brown,
 /turf/open/floor/iron/grimy,
 /area/station/commons)
 "AD" = (
@@ -1024,7 +1014,7 @@
 	width = 7
 	},
 /turf/open/floor/plating/airless,
-/area/station/external)
+/area/station/commons)
 "Ex" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -1061,7 +1051,7 @@
 /area/station/commons)
 "FC" = (
 /turf/open/floor/plating/airless,
-/area/station/external)
+/area/station/commons)
 "FN" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1181,10 +1171,6 @@
 /area/station/command/bridge)
 "JH" = (
 /obj/structure/table/reinforced,
-/obj/item/clothing/head/hardhat/orange{
-	pixel_x = -18;
-	pixel_y = 8
-	},
 /obj/item/phone{
 	pixel_x = 5;
 	pixel_y = 8
@@ -1195,7 +1181,13 @@
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 1
 	},
-/obj/item/clothing/head/cowboy_hat_red,
+/obj/item/clothing/head/utility/hardhat/weldhat/orange{
+	pixel_y = 7;
+	pixel_x = -5
+	},
+/obj/item/clothing/head/cowboy/red{
+	pixel_x = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "Ka" = (

--- a/_maps/voidcrew/ship_energia.dmm
+++ b/_maps/voidcrew/ship_energia.dmm
@@ -270,12 +270,6 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
 /area/station/medical)
-"ri" = (
-/obj/machinery/power/shuttle_engine/fueled/plasma{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/external)
 "rn" = (
 /obj/effect/turf_decal/stripes{
 	dir = 4
@@ -425,7 +419,7 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "xF" = (
-/obj/machinery/power/shuttle_engine/fueled/plasma{
+/obj/machinery/power/shuttle_engine/ship/fueled/plasma{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -541,10 +535,10 @@
 /turf/open/floor/iron,
 /area/station/medical)
 "BW" = (
-/obj/machinery/power/shuttle_engine/electric{
+/obj/structure/cable,
+/obj/machinery/power/shuttle_engine/ship/electric{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "CL" = (
@@ -970,13 +964,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "Wa" = (
-/obj/item/clothing/head/radiation,
-/obj/item/clothing/head/radiation,
-/obj/item/clothing/head/radiation,
 /obj/item/clothing/suit/utility/radiation,
 /obj/item/clothing/suit/utility/radiation,
 /obj/item/clothing/suit/utility/radiation,
 /obj/structure/closet/radiation,
+/obj/item/clothing/head/utility/radiation,
+/obj/item/clothing/head/utility/radiation,
+/obj/item/clothing/head/utility/radiation,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "WE" = (
@@ -1109,8 +1103,8 @@ AZ
 bC
 Ob
 Ob
-ri
-ri
+xF
+xF
 Ob
 TH
 bC

--- a/_maps/voidcrew/ship_goon.dmm
+++ b/_maps/voidcrew/ship_goon.dmm
@@ -139,7 +139,7 @@
 /turf/open/floor/mineral/titanium/white,
 /area/station/commons)
 "iC" = (
-/obj/machinery/power/shuttle_engine/fueled/plasma{
+/obj/machinery/power/shuttle_engine/ship/fueled/plasma{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -176,7 +176,7 @@
 /turf/open/floor/mineral/titanium/purple,
 /area/station/commons)
 "lK" = (
-/obj/machinery/power/shuttle_engine/fueled/plasma{
+/obj/machinery/power/shuttle_engine/ship/fueled/plasma{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -596,10 +596,10 @@
 /turf/open/floor/mineral/titanium/purple,
 /area/station/commons)
 "RZ" = (
-/obj/machinery/power/shuttle_engine/electric{
+/obj/structure/cable,
+/obj/machinery/power/shuttle_engine/ship/electric{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/medical)
 "SH" = (
@@ -676,10 +676,10 @@
 /turf/open/floor/mineral/titanium/yellow,
 /area/station/engineering)
 "YC" = (
-/obj/machinery/power/shuttle_engine/electric{
+/obj/structure/cable,
+/obj/machinery/power/shuttle_engine/ship/electric{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering)
 "YI" = (

--- a/_maps/voidcrew/ship_high.dmm
+++ b/_maps/voidcrew/ship_high.dmm
@@ -44,7 +44,7 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "bc" = (
-/obj/structure/mopbucket,
+/obj/effect/spawner/random/trash/mopbucket,
 /obj/item/mop,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
@@ -138,8 +138,15 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/office)
 "dA" = (
-/turf/template_noop,
-/area/station/external)
+/obj/structure/cable,
+/obj/machinery/power/shuttle_engine/ship/electric{
+	dir = 1
+	},
+/obj/machinery/power/shuttle_engine/ship/electric{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "dK" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -1311,7 +1318,7 @@
 "AG" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
-/area/station/external)
+/area/station/cargo/office)
 "AJ" = (
 /obj/machinery/holopad,
 /turf/open/floor/carpet,
@@ -1598,7 +1605,7 @@
 /area/station/commons/dorms)
 "GD" = (
 /turf/open/floor/plating,
-/area/station/external)
+/area/station/cargo/office)
 "GG" = (
 /obj/effect/turf_decal/siding/blue/corner{
 	dir = 4
@@ -1842,10 +1849,10 @@
 /turf/open/floor/carpet/stellar,
 /area/station/commons/lounge)
 "Kt" = (
-/obj/machinery/power/shuttle_engine/electric{
+/obj/structure/cable,
+/obj/machinery/power/shuttle_engine/ship/electric{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "Ku" = (
@@ -2132,8 +2139,7 @@
 /area/station/hallway/primary/central)
 "OT" = (
 /obj/machinery/light/floor,
-/turf/open/floor/catwalk_floor,
-/area/station/external)
+/turf/open/floor/catwalk_floor)
 "Pj" = (
 /obj/machinery/atmospherics/components/trinary/mixer/airmix{
 	dir = 8
@@ -2329,7 +2335,7 @@
 "UB" = (
 /obj/structure/window/reinforced/spawner/north,
 /turf/open/floor/catwalk_floor,
-/area/station/external)
+/area/station/engineering/atmos)
 "UO" = (
 /obj/structure/table/wood,
 /obj/item/areaeditor,
@@ -2408,8 +2414,7 @@
 /turf/open/floor/iron/white,
 /area/station/commons/dorms)
 "We" = (
-/turf/open/floor/catwalk_floor,
-/area/station/external)
+/turf/open/floor/catwalk_floor)
 "Ww" = (
 /obj/machinery/light{
 	dir = 8
@@ -2769,7 +2774,7 @@ wX
 ii
 JE
 aN
-GD
+xO
 Aq
 "}
 (6,1,1) = {"
@@ -2896,7 +2901,7 @@ JE
 JE
 oQ
 fG
-Kt
+dA
 "}
 (9,1,1) = {"
 DH
@@ -3037,10 +3042,10 @@ Do
 ni
 ni
 Fu
-dA
-dA
-dA
-dA
+Aq
+Aq
+Aq
+Aq
 Fu
 ay
 hE
@@ -3079,11 +3084,11 @@ DH
 ni
 We
 We
-dA
-dA
-dA
-dA
-dA
+Aq
+Aq
+Aq
+Aq
+Aq
 AC
 Qf
 wM
@@ -3121,10 +3126,10 @@ Aq
 Aq
 Aq
 We
-dA
-dA
-dA
-dA
+Aq
+Aq
+Aq
+Aq
 AC
 AC
 GY

--- a/_maps/voidcrew/ship_hightide.dmm
+++ b/_maps/voidcrew/ship_hightide.dmm
@@ -693,10 +693,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "Dl" = (
-/obj/machinery/power/shuttle_engine/electric{
+/obj/structure/cable,
+/obj/machinery/power/shuttle_engine/ship/electric{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "Dn" = (

--- a/_maps/voidcrew/ship_honk.dmm
+++ b/_maps/voidcrew/ship_honk.dmm
@@ -434,15 +434,14 @@
 /turf/open/floor/plating,
 /area/station/commons)
 "MZ" = (
-/obj/machinery/power/shuttle_engine/electric{
+/obj/structure/cable,
+/obj/machinery/power/shuttle_engine/ship/electric{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter)
 "Nj" = (
 /obj/structure/table/glass,
-/obj/item/clothing/head/clownmitre,
 /obj/item/storage/toolbox/mechanical,
 /obj/machinery/light{
 	dir = 4
@@ -452,6 +451,7 @@
 /obj/item/clothing/neck/petcollar,
 /obj/item/bikehorn/golden,
 /obj/item/gun/ballistic/revolver/russian/soul,
+/obj/item/clothing/head/chaplain/clownmitre,
 /turf/open/floor/mineral/bananium,
 /area/station/commons)
 "NI" = (

--- a/_maps/voidcrew/ship_irish.dmm
+++ b/_maps/voidcrew/ship_irish.dmm
@@ -66,13 +66,6 @@
 "fo" = (
 /turf/template_noop,
 /area/template_noop)
-"fJ" = (
-/obj/structure/cable,
-/obj/machinery/power/shuttle_engine/electric{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/external)
 "fL" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/balaclava,
@@ -702,12 +695,12 @@
 /turf/open/floor/iron,
 /area/station/science)
 "PX" = (
-/obj/machinery/power/shuttle_engine/electric{
+/obj/structure/cable,
+/obj/machinery/power/shuttle_engine/ship/electric{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/external)
+/area/station/maintenance/aft)
 "Sj" = (
 /obj/machinery/cryopod,
 /obj/machinery/computer/cryopod{
@@ -808,7 +801,7 @@ PX
 PX
 PX
 PX
-fJ
+PX
 fo
 fo
 fo

--- a/_maps/voidcrew/ship_kilo.dmm
+++ b/_maps/voidcrew/ship_kilo.dmm
@@ -483,6 +483,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/clothing/head/utility/welding,
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "cJ" = (
@@ -823,7 +824,7 @@
 	},
 /obj/item/pai_card,
 /obj/item/clothing/shoes/cowboy/white,
-/obj/item/clothing/head/cowboy_hat_red,
+/obj/item/clothing/head/cowboy/red,
 /turf/open/floor/carpet,
 /area/station/commons)
 "jU" = (
@@ -958,11 +959,11 @@
 /obj/effect/turf_decal/stripes{
 	dir = 4
 	},
-/obj/machinery/power/shuttle_engine/electric{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/power/shuttle_engine/ship/electric{
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
@@ -1437,10 +1438,6 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/obj/item/clothing/head/welding{
-	pixel_x = -2;
-	pixel_y = 1
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes{
 	dir = 1
@@ -1536,13 +1533,13 @@
 /obj/item/clothing/shoes/cowboy,
 /obj/item/clothing/shoes/cowboy,
 /obj/item/clothing/shoes/cowboy,
-/obj/item/clothing/head/cowboy_hat_brown,
-/obj/item/clothing/head/cowboy_hat_brown,
-/obj/item/clothing/head/cowboy_hat_brown,
-/obj/item/clothing/head/cowboy_hat_brown,
-/obj/item/clothing/head/cowboy_hat_brown,
-/obj/item/clothing/head/cowboy_hat_brown,
 /obj/machinery/firealarm/directional/west,
+/obj/item/clothing/head/cowboy/brown,
+/obj/item/clothing/head/cowboy/brown,
+/obj/item/clothing/head/cowboy/brown,
+/obj/item/clothing/head/cowboy/brown,
+/obj/item/clothing/head/cowboy/brown,
+/obj/item/clothing/head/cowboy/brown,
 /turf/open/floor/mineral/plastitanium,
 /area/station/commons)
 "NI" = (
@@ -1603,7 +1600,7 @@
 /obj/effect/turf_decal/stripes{
 	dir = 4
 	},
-/obj/machinery/power/shuttle_engine/fueled/plasma{
+/obj/machinery/power/shuttle_engine/ship/fueled/plasma{
 	dir = 8
 	},
 /turf/open/floor/plating/airless,

--- a/_maps/voidcrew/ship_lamia.dmm
+++ b/_maps/voidcrew/ship_lamia.dmm
@@ -660,12 +660,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "cl" = (
-/obj/machinery/power/shuttle_engine/electric{
+/obj/structure/cable,
+/obj/machinery/power/shuttle_engine/ship/electric{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/external)
+/area/station/maintenance/aft)
 "cr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1229,9 +1229,6 @@
 "IJ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/spider/stickyweb,
-/obj/item/clothing/head/jackbros{
-	pixel_y = 7
-	},
 /obj/item/clothing/shoes/jackbros{
 	pixel_y = -8
 	},
@@ -1240,6 +1237,9 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
+	},
+/obj/item/clothing/head/costume/jackbros{
+	pixel_y = 7
 	},
 /turf/open/floor/engine/cult,
 /area/station/science)
@@ -1435,7 +1435,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/external)
+/area/station/maintenance/aft)
 "RD" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile{

--- a/_maps/voidcrew/ship_libertatia.dmm
+++ b/_maps/voidcrew/ship_libertatia.dmm
@@ -101,16 +101,13 @@
 	},
 /turf/open/floor/pod/light,
 /area/station/command/bridge)
-"cF" = (
-/turf/closed/wall/mineral/plastitanium,
-/area/station/external)
 "dD" = (
 /obj/effect/turf_decal/stripes,
 /turf/open/floor/mineral/plastitanium,
 /area/station/cargo/miningoffice)
 "eV" = (
 /obj/structure/cable,
-/obj/machinery/power/shuttle_engine/electric{
+/obj/machinery/power/shuttle_engine/ship/electric{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -156,7 +153,7 @@
 /area/station/command/bridge)
 "fq" = (
 /turf/open/floor/engine/hull,
-/area/station/external)
+/area/station/security/brig)
 "fG" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/station/security/brig)
@@ -332,7 +329,7 @@
 	dir = 8
 	},
 /turf/open/floor/engine/hull,
-/area/station/external)
+/area/station/security/brig)
 "pm" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -715,7 +712,7 @@
 /area/station/commons/lounge)
 "Cd" = (
 /obj/structure/cable,
-/obj/machinery/power/shuttle_engine/electric{
+/obj/machinery/power/shuttle_engine/ship/electric{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -1418,7 +1415,6 @@
 /obj/structure/rack,
 /obj/item/storage/bag/ore,
 /obj/item/storage/bag/ore,
-/obj/item/clothing/head/hardhat/orange,
 /obj/item/clothing/suit/hazardvest,
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = 32
@@ -1426,8 +1422,6 @@
 /obj/item/clothing/suit/hazardvest,
 /obj/item/pickaxe/improvised,
 /obj/item/pickaxe/improvised,
-/obj/item/clothing/head/hardhat/orange,
-/obj/item/clothing/head/hardhat/orange,
 /turf/open/floor/pod/light,
 /area/station/cargo/miningoffice)
 "XB" = (
@@ -1515,10 +1509,10 @@ XJ
 XJ
 XJ
 XJ
-cF
-cF
-cF
-cF
+fG
+fG
+fG
+fG
 XJ
 XJ
 XJ
@@ -1920,10 +1914,10 @@ XJ
 XJ
 XJ
 XJ
-cF
-cF
-cF
-cF
+fG
+fG
+fG
+fG
 XJ
 XJ
 XJ

--- a/_maps/voidcrew/ship_luxembourg.dmm
+++ b/_maps/voidcrew/ship_luxembourg.dmm
@@ -397,10 +397,10 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/station/command/bridge)
 "iR" = (
-/obj/machinery/power/shuttle_engine/fueled/plasma{
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/power/shuttle_engine/ship/fueled/plasma{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "iV" = (
@@ -709,7 +709,7 @@
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "sh" = (
-/obj/machinery/power/shuttle_engine/fueled/plasma{
+/obj/machinery/power/shuttle_engine/ship/fueled/plasma{
 	dir = 1
 	},
 /turf/open/floor/plating,

--- a/_maps/voidcrew/ship_mechaton.dmm
+++ b/_maps/voidcrew/ship_mechaton.dmm
@@ -1,10 +1,10 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ae" = (
-/obj/machinery/power/shuttle_engine/fueled/plasma{
+/obj/machinery/power/shuttle_engine/ship/fueled/plasma{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/external)
+/area/station/engineering/main)
 "bf" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -50,8 +50,7 @@
 	dir = 10
 	},
 /obj/structure/lattice/catwalk,
-/turf/open/floor/plating,
-/area/station/external)
+/turf/open/floor/plating)
 "ey" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/stripes/box,
@@ -576,8 +575,6 @@
 /obj/item/radio,
 /obj/item/radio,
 /obj/item/tank/internals/plasmaman/full,
-/obj/item/clothing/head/hardhat/red,
-/obj/item/clothing/head/hardhat/red,
 /obj/item/clothing/suit/hazardvest,
 /obj/item/clothing/suit/hazardvest,
 /obj/item/clothing/suit/hazardvest,
@@ -935,8 +932,7 @@
 "My" = (
 /obj/structure/railing,
 /obj/structure/lattice/catwalk,
-/turf/open/floor/plating,
-/area/station/external)
+/turf/open/floor/plating)
 "MW" = (
 /obj/machinery/light{
 	dir = 8
@@ -995,12 +991,12 @@
 /turf/open/floor/noslip,
 /area/station/hallway/primary/central)
 "OT" = (
-/obj/machinery/power/shuttle_engine/electric{
+/obj/structure/cable,
+/obj/machinery/power/shuttle_engine/ship/electric{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/external)
+/area/station/engineering/main)
 "Pc" = (
 /turf/closed/wall/r_wall,
 /area/station/hallway/primary/central)
@@ -1068,8 +1064,7 @@
 	pixel_x = -8
 	},
 /obj/structure/lattice/catwalk,
-/turf/open/floor/plating,
-/area/station/external)
+/turf/open/floor/plating)
 "Qo" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -1114,8 +1109,7 @@
 /area/station/engineering/main)
 "RD" = (
 /obj/structure/lattice/catwalk,
-/turf/open/floor/plating,
-/area/station/external)
+/turf/open/floor/plating)
 "Se" = (
 /obj/machinery/cryopod{
 	dir = 1
@@ -1231,8 +1225,7 @@
 	dir = 8
 	},
 /obj/structure/lattice/catwalk,
-/turf/open/floor/plating,
-/area/station/external)
+/turf/open/floor/plating)
 "VM" = (
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{

--- a/_maps/voidcrew/ship_meta.dmm
+++ b/_maps/voidcrew/ship_meta.dmm
@@ -165,10 +165,10 @@
 /turf/open/floor/iron/white,
 /area/station/commons/dorms)
 "ax" = (
-/obj/machinery/power/shuttle_engine/electric{
+/obj/structure/cable,
+/obj/machinery/power/shuttle_engine/ship/electric{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/station/engineering/main)
 "ay" = (
@@ -305,7 +305,7 @@
 /turf/open/floor/iron/white,
 /area/station/commons/dorms)
 "aL" = (
-/obj/machinery/power/shuttle_engine/fueled/plasma{
+/obj/machinery/power/shuttle_engine/ship/fueled/plasma{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
@@ -495,9 +495,9 @@
 /obj/structure/rack,
 /obj/item/storage/belt/utility,
 /obj/item/weldingtool,
-/obj/item/clothing/head/welding,
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/item/clothing/head/utility/welding,
 /turf/open/floor/iron/white,
 /area/station/cargo/warehouse)
 "bm" = (
@@ -1211,15 +1211,12 @@
 	pixel_x = -2;
 	pixel_y = -1
 	},
-/obj/item/clothing/head/welding{
-	pixel_x = -2;
-	pixel_y = 1
-	},
 /obj/machinery/computer/helm/viewscreen{
 	pixel_y = -30;
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/item/clothing/head/utility/welding,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "cJ" = (
@@ -1446,10 +1443,6 @@
 /area/station/cargo/warehouse)
 "dg" = (
 /obj/structure/rack,
-/obj/item/clothing/head/welding{
-	pixel_x = -3;
-	pixel_y = 5
-	},
 /obj/item/storage/toolbox/mechanical,
 /obj/item/multitool{
 	pixel_x = 7;
@@ -2096,11 +2089,11 @@
 /turf/open/floor/iron/white,
 /area/station/cargo/warehouse)
 "Un" = (
-/obj/machinery/power/shuttle_engine/electric{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
+	dir = 4
+	},
+/obj/machinery/power/shuttle_engine/ship/electric{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,

--- a/_maps/voidcrew/ship_metis.dmm
+++ b/_maps/voidcrew/ship_metis.dmm
@@ -1,12 +1,12 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ab" = (
-/mob/living/simple_animal/hostile/rat,
 /obj/item/trash/semki,
 /obj/item/trash/boritos,
 /obj/item/circuitboard/machine/nanite_programmer,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/trashcart,
 /obj/structure/cable,
+/mob/living/basic/mouse/rat,
 /turf/open/floor/plating,
 /area/station/commons/storage/primary)
 "ag" = (
@@ -568,9 +568,9 @@
 /area/station/hallway/primary/aft)
 "jS" = (
 /obj/effect/decal/cleanable/blood,
-/obj/item/bodypart/r_arm/robot,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/bodypart/arm/right/robot,
 /turf/open/floor/mineral/titanium/tiled,
 /area/station/science/robotics)
 "ka" = (
@@ -1022,9 +1022,9 @@
 /turf/open/floor/mineral/titanium/tiled,
 /area/station/commons/toilet)
 "sk" = (
-/obj/item/bodypart/r_leg/robot,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/item/bodypart/leg/right/robot,
 /turf/open/floor/mineral/titanium/tiled,
 /area/station/science/robotics)
 "sn" = (
@@ -1039,8 +1039,9 @@
 /area/station/science/robotics)
 "sp" = (
 /obj/effect/decal/cleanable/oil,
-/obj/item/bodypart/l_arm/robot,
 /obj/machinery/airalarm/directional/west,
+/obj/item/bodypart/arm/left/robot,
+/obj/item/bodypart/leg/left/robot,
 /turf/open/floor/mineral/titanium/tiled,
 /area/station/science/robotics)
 "sr" = (
@@ -1079,7 +1080,6 @@
 /area/station/service/cafeteria)
 "sV" = (
 /obj/effect/decal/cleanable/oil,
-/obj/item/bodypart/l_leg/robot,
 /turf/open/floor/mineral/titanium/tiled,
 /area/station/science/robotics)
 "to" = (
@@ -1100,10 +1100,7 @@
 "tw" = (
 /obj/machinery/suit_storage_unit/open,
 /obj/item/clothing/suit/costume/xenos,
-/obj/item/clothing/head/xenos{
-	pixel_x = -1;
-	pixel_y = 10
-	},
+/obj/item/clothing/head/costume/xenos,
 /turf/open/floor/plating,
 /area/station/hallway/primary/aft)
 "tG" = (
@@ -1154,7 +1151,7 @@
 /area/station/ai_monitored/aisat)
 "vh" = (
 /obj/structure/cable,
-/obj/machinery/power/shuttle_engine/fueled{
+/obj/machinery/power/shuttle_engine/ship/fueled/plasma{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -1782,10 +1779,10 @@
 /turf/open/floor/mineral/titanium/tiled,
 /area/station/commons/toilet)
 "Fr" = (
-/obj/machinery/power/shuttle_engine/electric{
+/obj/structure/cable,
+/obj/machinery/power/shuttle_engine/ship/electric{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "Fs" = (
@@ -2168,7 +2165,7 @@
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/lattice/catwalk,
 /turf/template_noop,
-/area/station/external)
+/area/station/engineering/main)
 "LG" = (
 /obj/machinery/holopad,
 /turf/open/floor/mineral/titanium/tiled/white,
@@ -2401,7 +2398,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/external)
+/area/station/commons/storage/primary)
 "PA" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/cable,

--- a/_maps/voidcrew/ship_midway.dmm
+++ b/_maps/voidcrew/ship_midway.dmm
@@ -5,10 +5,10 @@
 /turf/open/floor/plating,
 /area/station/engineering/storage)
 "ao" = (
-/obj/machinery/power/shuttle_engine/electric{
+/obj/structure/cable,
+/obj/machinery/power/shuttle_engine/ship/electric{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/station/engineering/storage)
 "aB" = (
@@ -160,7 +160,7 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "fs" = (
-/obj/machinery/power/shuttle_engine/fueled/plasma{
+/obj/machinery/power/shuttle_engine/ship/fueled/plasma{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
@@ -591,22 +591,19 @@
 /area/station/cargo/storage)
 "sz" = (
 /obj/structure/rack,
-/obj/item/clothing/head/welding{
-	pixel_x = -2;
-	pixel_y = 1
-	},
 /obj/item/storage/toolbox/mechanical{
 	pixel_x = -2;
 	pixel_y = -1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/clothing/head/utility/welding,
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "sN" = (
-/obj/machinery/power/shuttle_engine/electric{
+/obj/structure/cable,
+/obj/machinery/power/shuttle_engine/ship/electric{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/station/engineering/main)
 "tb" = (
@@ -649,7 +646,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "uX" = (
-/obj/structure/janitorialcart,
+/obj/structure/mop_bucket/janitorialcart,
 /turf/open/floor/plating,
 /area/station/engineering/storage)
 "uZ" = (
@@ -1632,7 +1629,7 @@
 /turf/template_noop,
 /area/template_noop)
 "Zr" = (
-/obj/machinery/power/shuttle_engine/fueled/plasma{
+/obj/machinery/power/shuttle_engine/ship/fueled/plasma{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,

--- a/_maps/voidcrew/ship_nano_bead.dmm
+++ b/_maps/voidcrew/ship_nano_bead.dmm
@@ -370,10 +370,10 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "wH" = (
-/obj/machinery/power/shuttle_engine/electric{
+/obj/structure/cable,
+/obj/machinery/power/shuttle_engine/ship/electric{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "wO" = (
@@ -495,7 +495,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "Gf" = (
-/obj/machinery/power/shuttle_engine/fueled/plasma{
+/obj/machinery/power/shuttle_engine/ship/fueled/plasma{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -641,9 +641,6 @@
 /obj/item/shield/riot,
 /obj/item/shield/riot,
 /obj/item/shield/riot,
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot,
 /obj/item/clothing/suit/armor/riot,
 /obj/item/clothing/suit/armor/riot,
 /obj/item/clothing/suit/armor/riot,
@@ -839,9 +836,6 @@
 /area/station/cargo/miningoffice)
 "VO" = (
 /obj/machinery/airalarm/directional/east,
-/obj/machinery/firealarm/directional/north{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
@@ -861,6 +855,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/firealarm/directional/north{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/security/brig)
 "Wz" = (

--- a/_maps/voidcrew/ship_nano_phalanx.dmm
+++ b/_maps/voidcrew/ship_nano_phalanx.dmm
@@ -536,10 +536,10 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "gB" = (
-/obj/machinery/power/shuttle_engine/electric{
+/obj/structure/cable,
+/obj/machinery/power/shuttle_engine/ship/electric{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "gP" = (
@@ -1706,7 +1706,7 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "xB" = (
-/obj/machinery/power/shuttle_engine/fueled/plasma{
+/obj/machinery/power/shuttle_engine/ship/fueled/plasma{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -1853,7 +1853,7 @@
 "zC" = (
 /obj/machinery/camera/directional/north,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/mopbucket,
+/obj/effect/spawner/random/trash/mopbucket,
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "zD" = (
@@ -3217,7 +3217,7 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "UT" = (
-/obj/structure/chair/sofa{
+/obj/structure/chair/sofa/middle{
 	dir = 8
 	},
 /turf/open/floor/carpet/blue,

--- a/_maps/voidcrew/ship_nano_thunderbird.dmm
+++ b/_maps/voidcrew/ship_nano_thunderbird.dmm
@@ -32,8 +32,7 @@
 /turf/open/floor/mineral/titanium,
 /area/station/commons/dorms)
 "dh" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/shuttle,
+/obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/station/command/bridge)
 "dm" = (
@@ -74,8 +73,7 @@
 /turf/open/floor/mineral/titanium,
 /area/station/hallway/primary/central)
 "dS" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/shuttle,
+/obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/station/commons/dorms)
 "eO" = (
@@ -137,8 +135,7 @@
 /turf/open/floor/plating,
 /area/station/security/brig)
 "hx" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/shuttle,
+/obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/station/security/brig)
 "hJ" = (
@@ -233,10 +230,10 @@
 /turf/closed/wall/mineral/titanium,
 /area/station/ai_monitored/security/armory)
 "nD" = (
-/obj/machinery/mineral/equipment_vendor,
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/computer/order_console/mining,
 /turf/open/floor/mineral/titanium,
 /area/station/cargo/miningoffice)
 "nV" = (
@@ -629,7 +626,7 @@
 /turf/open/floor/mineral/titanium,
 /area/station/hallway/primary/central)
 "MQ" = (
-/obj/machinery/power/shuttle_engine/fueled/plasma{
+/obj/machinery/power/shuttle_engine/ship/fueled/plasma{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -647,10 +644,10 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/station/engineering/main)
 "Oa" = (
-/obj/machinery/power/shuttle_engine/electric{
+/obj/structure/cable,
+/obj/machinery/power/shuttle_engine/ship/electric{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "OI" = (
@@ -851,8 +848,7 @@
 /turf/open/floor/mineral/titanium,
 /area/station/ai_monitored/security/armory)
 "Zy" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/shuttle,
+/obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "ZX" = (

--- a/_maps/voidcrew/ship_osprey.dmm
+++ b/_maps/voidcrew/ship_osprey.dmm
@@ -108,7 +108,7 @@
 /area/station/hallway/primary/aft)
 "aX" = (
 /turf/closed/wall/mineral/titanium,
-/area/station/external)
+/area/station/cargo/office)
 "bf" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -395,8 +395,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "ec" = (
-/obj/structure/janitorialcart,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/mop_bucket/janitorialcart,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "ef" = (
@@ -543,7 +543,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "fU" = (
-/obj/machinery/power/shuttle_engine/fueled/plasma{
+/obj/machinery/power/shuttle_engine/ship/fueled/plasma{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -1197,7 +1197,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "mp" = (
-/obj/machinery/power/shuttle_engine/fueled/plasma{
+/obj/machinery/power/shuttle_engine/ship/fueled/plasma{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -1501,10 +1501,10 @@
 /obj/item/pickaxe,
 /obj/item/storage/bag/ore,
 /obj/item/storage/bag/ore,
-/obj/item/clothing/head/hardhat/orange,
-/obj/item/clothing/head/hardhat/orange,
 /obj/item/mining_scanner,
 /obj/item/mining_scanner,
+/obj/item/clothing/head/utility/hardhat/orange,
+/obj/item/clothing/head/utility/hardhat/orange,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "oL" = (
@@ -1793,10 +1793,6 @@
 /area/station/hallway/primary/aft)
 "rX" = (
 /obj/item/bodypart/chest/robot,
-/obj/item/bodypart/r_leg/robot,
-/obj/item/bodypart/l_leg/robot,
-/obj/item/bodypart/r_arm/robot,
-/obj/item/bodypart/l_arm/robot,
 /obj/item/bodypart/head/robot,
 /obj/item/assembly/flash/handheld,
 /obj/item/assembly/flash/handheld,
@@ -1808,6 +1804,10 @@
 /obj/effect/decal/cleanable/oil,
 /obj/structure/cable,
 /obj/item/robot_suit,
+/obj/item/bodypart/leg/left/robot,
+/obj/item/bodypart/leg/right/robot,
+/obj/item/bodypart/arm/left/robot,
+/obj/item/bodypart/arm/right/robot,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "sf" = (
@@ -2126,6 +2126,9 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/station/command/bridge)
+"vv" = (
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "vz" = (
 /obj/structure/chair{
 	dir = 1
@@ -2892,10 +2895,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "Eu" = (
-/obj/machinery/power/shuttle_engine/electric{
+/obj/structure/cable,
+/obj/machinery/power/shuttle_engine/ship/electric{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "Ev" = (
@@ -3869,9 +3872,22 @@
 	},
 /turf/open/floor/plating,
 /area/station/service/janitor)
+"PC" = (
+/obj/structure/window/reinforced/plasma/spawner/east,
+/obj/structure/window/reinforced/plasma/spawner/north,
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "PJ" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/station/external)
+/obj/structure/window/reinforced/plasma/spawner/west,
+/obj/structure/window/reinforced/plasma/spawner/north,
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "PK" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/station/maintenance/starboard)
@@ -4161,17 +4177,7 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "Tu" = (
-/obj/machinery/space_heater,
-/obj/structure/window/reinforced/plasma/spawner,
-/obj/machinery/door/window/left/directional/east{
-	dir = 1;
-	name = "Engine Access"
-	},
-/obj/structure/window/reinforced/plasma/spawner/east,
-/obj/machinery/door/poddoor{
-	id = "osprey_thruster_starboard";
-	name = "Thruster Blast Door"
-	},
+/obj/structure/window/reinforced/plasma/spawner/north,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "Tw" = (
@@ -4411,10 +4417,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "Wh" = (
-/obj/machinery/power/shuttle_engine/electric{
+/obj/structure/cable,
+/obj/machinery/power/shuttle_engine/ship/electric{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "WJ" = (
@@ -5845,7 +5851,7 @@ wt
 ln
 sM
 yG
-PJ
+Lk
 aX
 XU
 XU
@@ -5903,7 +5909,7 @@ oW
 qP
 rD
 yG
-PJ
+Lk
 XU
 XU
 XU
@@ -6290,7 +6296,7 @@ jE
 Oe
 lO
 Yx
-Tu
+PJ
 fU
 "}
 (29,1,1) = {"
@@ -6347,7 +6353,7 @@ sH
 uu
 DC
 tF
-Yx
+vv
 Tu
 fU
 "}
@@ -6406,7 +6412,7 @@ eP
 He
 Pm
 Yx
-Tu
+PC
 fU
 "}
 (31,1,1) = {"

--- a/_maps/voidcrew/ship_osprey.dmm
+++ b/_maps/voidcrew/ship_osprey.dmm
@@ -1,31 +1,35 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ab" = (
-/obj/effect/turf_decal/tile/neutral/diagonal_edge,
-/obj/effect/turf_decal/tile/blue/anticorner,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
-/obj/structure/closet/secure_closet/medical3,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"ad" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/cargo/warehouse)
 "ae" = (
 /obj/machinery/light/small,
-/obj/structure/bed,
-/obj/item/bedsheet/captain,
 /obj/structure/curtain/cloth/fancy,
+/obj/structure/bed{
+	dir = 1
+	},
+/obj/item/bedsheet/captain{
+	dir = 1
+	},
 /turf/open/floor/carpet/royalblue,
 /area/station/command/bridge)
 "af" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
 	name = "Infirmary"
 	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
 "ao" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
@@ -38,24 +42,30 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "az" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/machinery/computer/rdconsole{
+	dir = 4
 	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 10
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/science/research)
 "aB" = (
 /obj/effect/turf_decal/stripes{
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/item/wirecutters,
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "aC" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/structure/cable/multilayer/connected,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/main)
 "aE" = (
-/obj/effect/turf_decal/siding/wood,
 /obj/item/radio,
 /obj/item/radio,
 /obj/item/radio,
@@ -94,8 +104,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/structure/table/reinforced,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/griddle,
+/obj/structure/window/spawner/north,
+/obj/structure/window/spawner/east,
+/turf/open/floor/iron/showroomfloor,
 /area/station/service/cafeteria)
 "aK" = (
 /obj/structure/cable,
@@ -115,18 +131,24 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/station/maintenance/port)
 "bn" = (
 /obj/structure/table/optable,
 /obj/machinery/defibrillator_mount/loaded{
 	pixel_y = 24
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron,
 /area/station/medical/medbay/central)
 "bs" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "bz" = (
@@ -156,11 +178,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "bI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 8
-	},
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "bL" = (
@@ -179,17 +197,16 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "bN" = (
-/obj/effect/turf_decal/stripes{
-	dir = 1
+/obj/machinery/power/terminal{
+	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/structure/cable/multilayer/connected,
+/turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/engineering/main)
 "bP" = (
 /turf/closed/wall/mineral/titanium,
 /area/station/hallway/primary/aft)
 "bQ" = (
-/obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -198,7 +215,9 @@
 /obj/machinery/door/airlock/atmos{
 	name = "Life Support"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
 /area/station/engineering/atmos)
 "cb" = (
 /obj/structure/sign/warning/electric_shock,
@@ -220,8 +239,22 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"ci" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "cj" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -230,14 +263,19 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "cm" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high,
-/turf/open/floor/iron,
-/area/station/cargo/office)
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/vending/wardrobe/science_wardrobe,
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/research)
 "cq" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /obj/machinery/door/poddoor/shutters{
@@ -248,13 +286,14 @@
 /area/station/service/cafeteria)
 "cr" = (
 /obj/machinery/firealarm/directional/east,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "cu" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/cafeteria)
 "cw" = (
-/obj/effect/turf_decal/siding/wood,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -267,6 +306,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "cK" = (
@@ -288,31 +328,30 @@
 /obj/item/reagent_containers/syringe{
 	pixel_x = 7
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 6
-	},
 /obj/item/storage/box/gloves,
 /obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
-"cS" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
+	dir = 8
 	},
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/medical/medbay/central)
+"cS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass,
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/station/hallway/primary/port)
 "cY" = (
 /obj/structure/cable,
 /obj/structure/window/reinforced/plasma/spawner,
@@ -327,6 +366,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "dj" = (
+/obj/structure/rack,
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/ore,
+/obj/item/mining_scanner,
+/obj/item/mining_scanner,
+/obj/item/clothing/head/utility/hardhat/orange,
+/obj/item/clothing/head/utility/hardhat/orange,
 /obj/machinery/button/door{
 	dir = 8;
 	id = "ospreydoors";
@@ -334,10 +382,10 @@
 	pixel_x = 24;
 	pixel_y = 10
 	},
-/obj/effect/turf_decal/trimline/neutral/warning,
 /obj/item/radio/intercom/directional/east{
 	pixel_y = -10
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "dm" = (
@@ -346,13 +394,17 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
+"dr" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningoffice)
 "dy" = (
 /obj/machinery/light,
 /obj/item/radio/intercom/directional/south,
-/obj/machinery/griddle,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/structure/table/reinforced,
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/cafeteria)
 "dI" = (
@@ -362,29 +414,33 @@
 /area/station/command/bridge)
 "dJ" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/stairs{
 	dir = 8
 	},
 /area/station/command/bridge)
 "dK" = (
 /obj/structure/railing,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/effect/landmark/start/captain,
 /obj/structure/chair/comfy/shuttle{
 	dir = 1;
 	name = "Helm"
 	},
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
-"ea" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
+/obj/effect/turf_decal/siding/thinplating_new/dark/end{
+	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/white,
+/area/station/command/bridge)
+"dW" = (
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/iron/dark/textured,
+/area/station/engineering/main)
+"ea" = (
+/obj/structure/sign/poster/official/random/directional/east,
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "eb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
@@ -397,6 +453,7 @@
 "ec" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/mop_bucket/janitorialcart,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "ef" = (
@@ -419,33 +476,51 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/service/janitor)
+"eo" = (
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "ep" = (
-/obj/effect/turf_decal/stripes{
-	dir = 8
-	},
-/obj/item/stack/sheet/mineral/plasma/thirty,
+/obj/structure/cable,
+/obj/machinery/power/port_gen/pacman/super,
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "eq" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable,
-/turf/open/floor/catwalk_floor,
+/turf/open/floor/iron/smooth_large,
 /area/station/engineering/main)
+"eA" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "eB" = (
-/obj/effect/turf_decal/tile/neutral/diagonal_edge,
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/wood,
 /area/station/medical/medbay/lobby)
+"eG" = (
+/obj/structure/chair/office,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/dark/diagonal_centre,
+/turf/open/floor/iron/white/diagonal,
+/area/station/science/robotics/lab)
 "eM" = (
 /obj/machinery/computer/atmos_alert{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/warning,
 /obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/smooth_large,
 /area/station/engineering/main)
 "eP" = (
 /obj/machinery/atmospherics/components/tank/plasma{
@@ -467,12 +542,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "fb" = (
-/obj/effect/turf_decal/stripes{
-	dir = 1
-	},
-/obj/machinery/power/terminal,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/machinery/power/smes/engineering,
+/turf/open/floor/iron/smooth_large,
 /area/station/engineering/main)
 "ff" = (
 /obj/machinery/atmospherics/components/tank/plasma{
@@ -487,22 +559,25 @@
 /obj/item/clothing/head/soft/purple,
 /obj/item/radio/intercom/directional/south,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "fq" = (
 /obj/effect/landmark/start/shaft_miner,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "fx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	id = "ospreywindows";
+	name = "Blast Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/command/heads_quarters/qm)
 "fD" = (
 /obj/structure/chair/office,
-/obj/effect/landmark/start/quartermaster,
+/obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "fE" = (
@@ -511,9 +586,12 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "fI" = (
-/obj/effect/turf_decal/box,
-/turf/open/floor/iron/dark,
-/area/station/cargo/miningoffice)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/hallway/primary/starboard)
 "fL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -528,18 +606,16 @@
 	},
 /obj/structure/chair/stool/bar,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "fS" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "fU" = (
@@ -556,17 +632,19 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "fZ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "gb" = (
@@ -581,17 +659,13 @@
 /obj/machinery/door/airlock/research/glass{
 	name = "Laboratory"
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/research)
 "gh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
@@ -599,7 +673,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/dark,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
 /area/station/hallway/primary/starboard)
 "gm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
@@ -607,6 +682,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "gr" = (
@@ -617,16 +695,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "gu" = (
-/obj/effect/turf_decal/stripes{
-	dir = 10
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "gy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/catwalk_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "gB" = (
 /obj/structure/cable,
@@ -637,10 +714,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"gC" = (
+/obj/effect/turf_decal/bot_white/right,
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningoffice)
 "gD" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
+/obj/effect/turf_decal/tile/brown{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
@@ -649,35 +732,56 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/station/maintenance/starboard)
 "gM" = (
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron/dark,
+/obj/item/wallframe/camera,
+/obj/item/wallframe/camera,
+/obj/item/wallframe/camera,
+/obj/item/wallframe/camera,
+/obj/item/wallframe/camera,
+/obj/item/wallframe/camera,
+/obj/item/wallframe/camera,
+/obj/item/wallframe/camera,
+/obj/item/wallframe/camera,
+/obj/item/wallframe/camera{
+	name = "spare parts crate"
+	},
+/obj/structure/closet/crate/science,
+/obj/item/circuitboard/computer/borgupload,
+/obj/item/circuitboard/machine/cyborgrecharger,
+/obj/item/circuitboard/computer/aiupload,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/red/diagonal_centre,
+/turf/open/floor/iron/white/diagonal,
 /area/station/science/robotics/lab)
 "gU" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/warning,
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/plating,
 /area/station/engineering/atmos)
 "gX" = (
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "hk" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "hq" = (
-/obj/effect/spawner/structure/window/reinforced/shuttle,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "ospreysci"
 	},
-/obj/structure/grille,
+/obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/station/science/research)
 "hw" = (
@@ -686,8 +790,18 @@
 "hz" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark/filled/warning{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "hB" = (
@@ -695,10 +809,6 @@
 /area/station/science/robotics/lab)
 "hC" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/item/paper_bin{
 	pixel_x = -6
 	},
@@ -729,636 +839,20 @@
 	pixel_x = -22;
 	pixel_y = -6
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/dark_blue/half{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
 /area/station/command/bridge)
 "hM" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
 /obj/effect/landmark/start/assistant,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/station/commons/dorms)
-"il" = (
-/obj/machinery/power/terminal,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/port)
-"ip" = (
-/obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/station/cargo/office)
-"iq" = (
-/obj/machinery/mineral/ore_redemption,
-/obj/machinery/door/firedoor/heavy,
-/turf/open/space/basic,
-/area/station/cargo/warehouse)
-"it" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -6
-	},
-/obj/item/pen{
-	pixel_x = 7
-	},
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron,
-/area/station/cargo/office)
-"iw" = (
-/obj/item/paper_bin{
-	pixel_x = 6
-	},
-/obj/item/clipboard{
-	pixel_x = -7
-	},
-/obj/item/folder/white{
-	pixel_x = -7
-	},
-/obj/item/pen{
-	pixel_x = -7
-	},
-/obj/item/stamp/cmo{
-	pixel_x = -1;
-	pixel_y = 12
-	},
-/obj/machinery/door/firedoor/heavy,
-/obj/structure/table/reinforced/rglass,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
-"iy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/junction/flip,
-/obj/effect/turf_decal/tile/neutral/diagonal_edge,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
-"iC" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/railing,
-/obj/item/storage/fancy/cigarettes/cigars{
-	pixel_y = 12
-	},
-/obj/item/areaeditor{
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/obj/item/lighter{
-	pixel_x = -6;
-	pixel_y = -3
-	},
-/obj/machinery/button/door{
-	dir = 8;
-	id = "ospreydoors";
-	name = "Blast Door Control";
-	pixel_x = 24;
-	pixel_y = 10
-	},
-/obj/item/taperecorder,
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
-"iF" = (
-/turf/closed/wall/mineral/titanium,
-/area/station/hallway/primary/port)
-"iH" = (
-/obj/effect/turf_decal/stripes{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/structure/sign/warning/engine_safety/directional/north,
-/turf/open/floor/catwalk_floor,
-/area/station/engineering/main)
-"iO" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
-"iS" = (
-/obj/effect/turf_decal/trimline/neutral/warning,
-/obj/machinery/atmospherics/components/tank/air{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
-"ja" = (
-/turf/closed/wall/mineral/titanium,
-/area/station/cargo/warehouse)
-"jf" = (
-/obj/structure/sign/warning/vacuum/external,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/station/maintenance/port)
-"jg" = (
-/obj/machinery/suit_storage_unit/engine,
-/obj/effect/turf_decal/bot,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/engineering/main)
-"jh" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/poddoor{
-	id = "ospreydoors";
-	name = "Cargo Bay Blast Door"
-	},
-/turf/open/floor/circuit/red,
-/area/station/cargo/miningoffice)
-"jn" = (
-/turf/open/floor/circuit,
-/area/station/science/robotics/lab)
-"js" = (
-/obj/effect/turf_decal/stripes{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/catwalk_floor,
-/area/station/engineering/main)
-"jy" = (
-/obj/machinery/vending/dinnerware,
-/turf/open/floor/iron/showroomfloor,
-/area/station/service/cafeteria)
-"jA" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/obj/structure/table,
-/obj/item/flashlight/lamp,
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/wood,
-/area/station/service/cafeteria)
-"jC" = (
-/obj/structure/closet/wardrobe/grey,
-/turf/open/floor/carpet,
-/area/station/commons/dorms)
-"jE" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard)
-"jN" = (
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/lab)
-"jP" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
-"jS" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 5
-	},
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Infirmary"
-	},
-/turf/open/floor/iron/white,
-/area/station/hallway/primary/aft)
-"jT" = (
-/obj/effect/turf_decal/tile/neutral/diagonal_edge,
-/obj/effect/turf_decal/tile/blue/anticorner{
-	dir = 4
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/firealarm/directional/east{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
-"jU" = (
-/obj/effect/turf_decal/stripes{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/engineering/main)
-"jV" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/station/service/cafeteria)
-"ka" = (
-/obj/machinery/pipedispenser,
-/obj/effect/turf_decal/trimline/neutral/warning,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
-"kf" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
-"ki" = (
-/obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor/shutters{
-	id = "ospreywindows";
-	name = "Blast Shutters"
-	},
-/turf/open/floor/plating,
-/area/station/cargo/warehouse)
-"kj" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/status_display/shuttle{
-	pixel_y = 32
-	},
-/obj/machinery/suit_storage_unit/standard_unit,
-/turf/open/floor/iron/dark,
-/area/station/cargo/miningoffice)
-"kl" = (
-/obj/effect/turf_decal/siding/wood/corner,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/grimy,
-/area/station/commons/dorms)
-"kp" = (
-/obj/effect/turf_decal/stripes{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/starboard)
-"kq" = (
-/obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor/shutters{
-	id = "ospreywindows";
-	name = "Blast Shutters"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/main)
-"kE" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/lab)
-"kJ" = (
-/obj/effect/turf_decal/caution/stand_clear{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/starboard)
-"kO" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Engineering"
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/station/engineering/main)
-"kU" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
-"kW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/hallway/primary/port)
-"lc" = (
-/obj/item/storage/bag/trash,
-/obj/item/mop,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/service/janitor)
-"lf" = (
-/obj/machinery/suit_storage_unit/atmos,
-/obj/effect/turf_decal/bot,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
-"lg" = (
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/commons/dorms)
-"lh" = (
-/obj/structure/chair/office,
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/carpet,
-/area/station/commons/dorms)
-"li" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/machinery/computer/helm,
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
-"lk" = (
-/obj/effect/turf_decal/tile/neutral/diagonal_edge,
-/obj/effect/turf_decal/tile/blue/anticorner,
-/obj/machinery/light,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
-"ln" = (
-/turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
-"lq" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
-"lO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard)
-"lT" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/lab)
-"lU" = (
-/turf/open/floor/engine/hull,
-/area/station/engineering/main)
-"lX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/engineering/main)
-"lY" = (
-/obj/effect/turf_decal/stripes{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/lab)
-"md" = (
-/obj/machinery/door/airlock/maintenance/external,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
-/area/station/hallway/primary/starboard)
-"mj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "ospreybridge"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/blue{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
-"mk" = (
-/obj/effect/decal/cleanable/oil,
-/turf/open/floor/circuit,
-/area/station/science/robotics/lab)
-"ml" = (
-/obj/effect/turf_decal/stripes{
-	dir = 9
-	},
-/obj/machinery/power/port_gen/pacman/pre_loaded,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/engineering/main)
-"mn" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/engine/hull,
-/area/station/engineering/main)
-"mo" = (
-/obj/structure/cable,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/junction/flip,
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
-"mp" = (
-/obj/machinery/power/shuttle_engine/ship/fueled/plasma{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/port)
-"mv" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Cargo Bay"
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
-/area/station/cargo/office)
-"mE" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/station/commons/dorms)
-"mI" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/hallway/primary/starboard)
-"mJ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron,
-/area/station/cargo/office)
-"mQ" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/suit_storage_unit/standard_unit,
-/turf/open/floor/iron/dark,
-/area/station/cargo/miningoffice)
-"mR" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/hallway/primary/port)
-"mV" = (
-/obj/item/wallframe/camera,
-/obj/item/wallframe/camera,
-/obj/item/wallframe/camera,
-/obj/item/wallframe/camera,
-/obj/item/wallframe/camera,
-/obj/item/wallframe/camera,
-/obj/item/wallframe/camera,
-/obj/item/wallframe/camera,
-/obj/item/wallframe/camera,
-/obj/item/wallframe/camera{
-	name = "spare parts crate"
-	},
-/obj/structure/closet/crate/science,
-/obj/item/circuitboard/computer/borgupload,
-/obj/item/circuitboard/machine/cyborgrecharger,
-/obj/item/circuitboard/computer/aiupload,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/lab)
-"na" = (
-/obj/effect/landmark/start/scientist,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/science/research)
-"nh" = (
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/port)
-"nk" = (
-/obj/effect/turf_decal/tile/neutral/diagonal_edge,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
-"nl" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
-"nn" = (
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
-"no" = (
-/obj/structure/cable,
-/obj/structure/window/reinforced/plasma/spawner,
-/obj/machinery/door/window/right/directional/east{
-	dir = 1;
-	name = "Engine Access"
-	},
-/obj/structure/window/reinforced/plasma/spawner/east,
-/obj/machinery/power/smes/engineering{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/port)
-"ns" = (
-/obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor/shutters{
-	id = "ospreywindows";
-	name = "Blast Shutters"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/engineering/main)
-"nu" = (
-/obj/effect/spawner/random/maintenance/three,
-/obj/structure/closet/cardboard{
-	name = "forgotten IKEA box"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/port)
-"nI" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
-"nK" = (
-/obj/machinery/light,
-/obj/structure/cable,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/lab)
-"nM" = (
-/obj/structure/table,
-/obj/item/clothing/glasses/welding,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/lab)
-"nO" = (
+"hN" = (
 /obj/item/food/canned/beans{
 	pixel_x = -5;
 	pixel_y = 3
@@ -1392,14 +886,656 @@
 /obj/item/food/rationpack,
 /obj/item/food/rationpack,
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/smooth,
+/area/station/cargo/warehouse)
+"il" = (
+/obj/machinery/power/terminal,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
+"ip" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/turf/open/floor/plating,
+/area/station/cargo/office)
+"iq" = (
+/obj/machinery/mineral/ore_redemption,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/station/cargo/warehouse)
+"it" = (
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
+/area/station/hallway/primary/aft)
+"iw" = (
+/obj/item/paper_bin{
+	pixel_x = 6
+	},
+/obj/item/clipboard{
+	pixel_x = -7
+	},
+/obj/item/folder/white{
+	pixel_x = -7
+	},
+/obj/item/pen{
+	pixel_x = -7
+	},
+/obj/item/stamp/cmo{
+	pixel_x = -1;
+	pixel_y = 12
+	},
+/obj/structure/table/reinforced/rglass,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
+"iy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/junction/flip,
+/turf/open/floor/wood,
+/area/station/medical/medbay/lobby)
+"iC" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/railing,
+/obj/item/storage/fancy/cigarettes/cigars{
+	pixel_y = 12
+	},
+/obj/item/areaeditor{
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/item/lighter{
+	pixel_x = -6;
+	pixel_y = -3
+	},
+/obj/machinery/button/door{
+	dir = 8;
+	id = "ospreydoors";
+	name = "Blast Door Control";
+	pixel_x = 24;
+	pixel_y = 10
+	},
+/obj/item/taperecorder,
+/obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/tile/dark_blue/half{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 4
+	},
+/area/station/command/bridge)
+"iF" = (
+/turf/closed/wall/mineral/titanium,
+/area/station/hallway/primary/port)
+"iH" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/structure/sign/warning/engine_safety/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/engineering/main)
+"iO" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
+"iS" = (
+/obj/machinery/atmospherics/components/tank/air{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
+"ja" = (
+/turf/closed/wall/mineral/titanium,
+/area/station/cargo/warehouse)
+"jf" = (
+/obj/structure/sign/warning/vacuum/external,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/station/maintenance/port)
+"jg" = (
+/obj/structure/closet/secure_closet/engineering_personal,
+/obj/item/clothing/gloves/color/yellow,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes,
+/turf/open/floor/iron/dark,
+/area/station/engineering/main)
+"jh" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/poddoor{
+	id = "ospreydoors";
+	name = "Cargo Bay Blast Door"
+	},
+/obj/effect/turf_decal/stripes,
+/turf/open/floor/plating,
+/area/station/cargo/miningoffice)
+"jn" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new,
+/turf/open/floor/circuit/off,
+/area/station/science/robotics/lab)
+"js" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/engineering/main)
+"jy" = (
+/obj/machinery/vending/dinnerware,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/turf/open/floor/iron/showroomfloor,
+/area/station/service/cafeteria)
+"jA" = (
+/obj/machinery/firealarm/directional/north,
+/obj/effect/spawner/random/vending/colavend,
+/turf/open/floor/wood,
+/area/station/service/cafeteria)
+"jC" = (
+/obj/structure/closet/wardrobe/grey,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/carpet,
+/area/station/commons/dorms)
+"jE" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
+"jN" = (
+/obj/structure/frame/computer{
+	anchored = 1;
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/dark/diagonal_centre,
+/turf/open/floor/iron/white/diagonal,
+/area/station/science/robotics/lab)
+"jP" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
+"jS" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/public/glass{
+	name = "Infirmary"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
+"jT" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/east{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/station/medical/medbay/lobby)
+"jU" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
+"jV" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/station/service/cafeteria)
+"ka" = (
+/obj/machinery/pipedispenser,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/effect/turf_decal/stripes,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
+"kf" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"ki" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	id = "ospreywindows";
+	name = "Blast Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/cargo/warehouse)
+"kj" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/status_display/shuttle{
+	pixel_y = 32
+	},
+/obj/machinery/suit_storage_unit/standard_unit,
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningoffice)
+"kl" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/grimy,
+/area/station/commons/dorms)
+"kp" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
+"kq" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	id = "ospreywindows";
+	name = "Blast Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/main)
+"kw" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
+"kE" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/science/robotics/lab)
+"kJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
+"kO" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Engineering"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/engineering/main)
+"kU" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
+"kW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/stack/tile/iron/dark,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/station/hallway/primary/port)
+"lc" = (
+/obj/item/storage/bag/trash,
+/obj/item/mop,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/service/janitor)
+"lf" = (
+/obj/machinery/suit_storage_unit/atmos,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
+"lg" = (
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/commons/dorms)
+"lh" = (
+/obj/structure/chair/office,
+/obj/effect/landmark/start/assistant,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/station/commons/dorms)
+"li" = (
+/obj/machinery/computer/helm,
+/obj/effect/turf_decal/tile/dark_blue/half{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
+/area/station/command/bridge)
+"lk" = (
+/obj/machinery/light,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
+"ln" = (
+/obj/structure/frame/computer{
+	anchored = 1;
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/station/cargo/warehouse)
+"lq" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"lO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
+"lT" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/science/robotics/lab)
+"lU" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/turf/open/floor/engine/hull,
+/area/station/engineering/main)
+"lX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/layer3,
+/obj/effect/turf_decal/stripes,
+/turf/open/floor/iron/dark,
+/area/station/engineering/main)
+"lY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/science/robotics/lab)
+"md" = (
+/obj/machinery/door/airlock/maintenance/external,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/hallway/primary/starboard)
+"mj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "ospreybridge"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
+"mk" = (
+/obj/effect/decal/cleanable/oil,
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 8
+	},
+/turf/open/floor/circuit/off,
+/area/station/science/robotics/lab)
+"ml" = (
+/obj/structure/cable,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/engineering/main)
+"mn" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/turf/open/floor/engine/hull,
+/area/station/engineering/main)
+"mo" = (
+/obj/structure/cable,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/junction/flip,
+/turf/open/floor/catwalk_floor/iron,
+/area/station/hallway/primary/aft)
+"mp" = (
+/obj/machinery/power/shuttle_engine/ship/fueled/plasma{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port)
+"mv" = (
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Bay"
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/cargo/office)
+"mE" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/station/commons/dorms)
+"mI" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark,
+/area/station/hallway/primary/starboard)
+"mJ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/airalarm/directional/east,
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/bin,
+/turf/open/floor/iron,
+/area/station/cargo/office)
+"mQ" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/suit_storage_unit/standard_unit,
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningoffice)
+"mR" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/hallway/primary/port)
+"mV" = (
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/science/robotics/lab)
+"mX" = (
+/obj/item/stack/pipe_cleaner_coil/cut/yellow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/engineering/main)
+"na" = (
+/obj/effect/landmark/start/scientist,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/science/research)
+"nh" = (
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
+"nk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
+"nl" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
+"nn" = (
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"no" = (
+/obj/structure/cable,
+/obj/structure/window/reinforced/plasma/spawner,
+/obj/machinery/door/window/right/directional/east{
+	dir = 1;
+	name = "Engine Access"
+	},
+/obj/structure/window/reinforced/plasma/spawner/east,
+/obj/machinery/power/smes/engineering{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port)
+"ns" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	id = "ospreywindows";
+	name = "Blast Shutters"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/engineering/main)
+"nu" = (
+/obj/effect/spawner/random/maintenance/three,
+/obj/structure/closet/cardboard{
+	name = "forgotten IKEA box"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port)
+"nI" = (
+/obj/machinery/autolathe,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 5
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark/textured,
+/area/station/science/research)
+"nK" = (
+/obj/item/bodypart/chest/robot,
+/obj/item/bodypart/head/robot,
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
+/obj/item/stock_parts/cell/hyper,
+/obj/item/stack/cable_coil,
+/obj/structure/closet/cardboard{
+	name = "forgotten IKEA box"
+	},
+/obj/effect/decal/cleanable/oil,
+/obj/structure/cable,
+/obj/item/robot_suit,
+/obj/item/bodypart/leg/left/robot,
+/obj/item/bodypart/leg/right/robot,
+/obj/item/bodypart/arm/left/robot,
+/obj/item/bodypart/arm/right/robot,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron,
+/area/station/science/robotics/lab)
+"nM" = (
+/obj/structure/table,
+/obj/item/clothing/glasses/welding,
+/obj/effect/turf_decal/siding/red{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/thinplating_new/light/corner{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
+"nO" = (
+/obj/structure/closet/crate,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/effect/decal/cleanable/oil,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/smooth,
 /area/station/cargo/warehouse)
 "nS" = (
 /obj/item/kirbyplants/random,
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
@@ -1413,11 +1549,10 @@
 /turf/closed/wall/mineral/titanium,
 /area/station/hallway/primary/starboard)
 "oa" = (
-/obj/effect/spawner/structure/window/reinforced/shuttle,
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/structure/grille,
+/obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/station/medical/medbay/lobby)
 "ob" = (
@@ -1427,17 +1562,20 @@
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "og" = (
-/obj/structure/chair/office{
-	dir = 4
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 2
 	},
-/turf/open/floor/iron/dark,
-/area/station/cargo/miningoffice)
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "ok" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/junction,
-/obj/effect/turf_decal/tile/neutral/diagonal_edge,
-/turf/open/floor/iron/white,
+/turf/open/floor/wood,
 /area/station/medical/medbay/lobby)
 "op" = (
 /obj/machinery/power/terminal,
@@ -1449,10 +1587,14 @@
 /area/station/maintenance/starboard)
 "ow" = (
 /obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "ox" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "oy" = (
@@ -1470,7 +1612,10 @@
 	launch_status = 0;
 	port_direction = 8
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/station/maintenance/port)
 "oE" = (
 /obj/structure/cable,
@@ -1481,6 +1626,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "oI" = (
@@ -1492,58 +1640,72 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "oK" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/rack,
-/obj/item/pickaxe,
-/obj/item/pickaxe,
-/obj/item/storage/bag/ore,
-/obj/item/storage/bag/ore,
-/obj/item/mining_scanner,
-/obj/item/mining_scanner,
-/obj/item/clothing/head/utility/hardhat/orange,
-/obj/item/clothing/head/utility/hardhat/orange,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/obj/machinery/firealarm/directional/west,
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/qm)
 "oL" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/visible{
 	dir = 4
 	},
-/turf/open/floor/catwalk_floor,
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/station/engineering/atmos)
 "oO" = (
-/obj/structure/mecha_wreckage/ripley,
 /obj/effect/decal/cleanable/oil,
 /obj/item/radio/intercom/directional/west{
 	pixel_y = -6
 	},
-/turf/open/floor/iron/dark,
+/obj/structure/frame/machine,
+/obj/item/stack/cable_coil/cut,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "oP" = (
 /obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/oil/streak,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/structure/closet/crate/internals,
+/turf/open/floor/iron/smooth,
 /area/station/cargo/warehouse)
 "oR" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/status_display/shuttle{
 	pixel_y = 32
 	},
-/turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
-"oW" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/crate{
-	name = "food crate"
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/station/command/heads_quarters/qm)
+"oT" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
-/obj/effect/spawner/random/maintenance/three,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/science/robotics/lab)
+"oW" = (
+/obj/machinery/door/airlock/command,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/qm)
 "pf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/cable,
@@ -1552,11 +1714,15 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "pi" = (
-/obj/structure/table_frame,
-/turf/open/floor/iron/dark,
+/obj/structure/mecha_wreckage/ripley,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/recharge_floor,
 /area/station/science/robotics/lab)
 "pr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1565,24 +1731,30 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "ps" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 2
 	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/station/hallway/primary/aft)
 "pC" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes,
+/turf/open/floor/plating,
 /area/station/engineering/atmos)
 "pE" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "pJ" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/structure/grille,
 /turf/open/floor/plating,
 /area/station/commons/dorms)
 "pO" = (
@@ -1592,9 +1764,6 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/station/service/janitor)
 "pU" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1607,22 +1776,35 @@
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "qc" = (
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/circuit,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new,
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/circuit/off,
 /area/station/science/robotics/lab)
 "qe" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/crate,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/supplypod_beacon,
-/turf/open/floor/iron,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/smooth,
 /area/station/cargo/warehouse)
 "qf" = (
 /turf/closed/wall/mineral/titanium,
 /area/station/engineering/main)
 "qg" = (
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "qj" = (
 /obj/structure/cable,
@@ -1650,20 +1832,18 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/obj/item/stack/tile/iron/dark,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
 /area/station/hallway/primary/starboard)
 "qC" = (
-/obj/effect/turf_decal/stripes{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=med";
 	location = "cargo"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/cargo/warehouse)
 "qD" = (
 /obj/machinery/light/small,
@@ -1671,45 +1851,35 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/turf/open/floor/plating,
 /area/station/maintenance/port)
 "qK" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/disposalpipe/trunk{
 	dir = 2
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "qO" = (
-/obj/structure/closet/crate,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
+/obj/structure/frame/machine,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "qP" = (
-/obj/structure/closet/crate,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/oil,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
-"qT" = (
-/obj/effect/turf_decal/stripes{
+/obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/circuit,
+/turf/open/floor/wood,
+/area/station/cargo/warehouse)
+"qT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron_white,
 /area/station/science/robotics/lab)
 "qZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/engineering/main)
 "rh" = (
 /obj/structure/cable,
@@ -1718,7 +1888,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/turf/open/floor/catwalk_floor,
+/turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "rj" = (
 /turf/open/floor/wood,
@@ -1728,28 +1898,27 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/service/janitor)
 "rq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/station/command/bridge)
 "rs" = (
+/obj/structure/sign/poster/official/random/directional/west,
 /obj/structure/frame/computer{
 	anchored = 1;
 	dir = 4
 	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "ru" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -1764,24 +1933,45 @@
 /area/station/commons/dorms)
 "rv" = (
 /obj/effect/landmark/start/cook,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/cafeteria)
 "rD" = (
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/wood,
 /area/station/cargo/warehouse)
 "rF" = (
-/obj/item/trash/can/food,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/table,
+/obj/effect/turf_decal/siding/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
+"rJ" = (
+/obj/structure/frame/machine,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 6
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark/textured,
+/area/station/science/research)
 "rM" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/station/maintenance/port)
 "rW" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1789,26 +1979,15 @@
 	dir = 2
 	},
 /obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/catwalk_floor/iron,
 /area/station/hallway/primary/aft)
 "rX" = (
-/obj/item/bodypart/chest/robot,
-/obj/item/bodypart/head/robot,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/stock_parts/cell/hyper,
-/obj/item/stack/cable_coil,
-/obj/structure/closet/cardboard{
-	name = "forgotten IKEA box"
-	},
-/obj/effect/decal/cleanable/oil,
 /obj/structure/cable,
-/obj/item/robot_suit,
-/obj/item/bodypart/leg/left/robot,
-/obj/item/bodypart/leg/right/robot,
-/obj/item/bodypart/arm/left/robot,
-/obj/item/bodypart/arm/right/robot,
-/turf/open/floor/iron/dark,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/filingcabinet/chestdrawer,
+/obj/machinery/light,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "sf" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
@@ -1819,7 +1998,8 @@
 /obj/item/radio/intercom{
 	pixel_y = 22
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
 /area/station/hallway/primary/port)
 "sn" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
@@ -1829,26 +2009,28 @@
 	},
 /turf/open/floor/plating,
 /area/station/hallway/primary/aft)
+"sr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark,
+/area/station/hallway/primary/port)
 "sw" = (
-/obj/effect/turf_decal/stripes{
-	dir = 4
-	},
-/obj/item/stack/sheet/mineral/plasma/thirty,
+/obj/structure/cable,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "sB" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/station/command/bridge)
 "sG" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
 	name = "Canteen"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/service/cafeteria)
@@ -1856,13 +2038,31 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/station/maintenance/starboard)
+"sK" = (
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/cargo/warehouse)
 "sM" = (
 /obj/machinery/light,
-/obj/structure/cable,
 /obj/machinery/status_display/shuttle{
 	pixel_y = -32
 	},
-/turf/open/floor/iron/dark,
+/obj/structure/closet/crate,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/supplypod_beacon,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/smooth,
 /area/station/cargo/warehouse)
 "sN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1872,19 +2072,16 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "ospreybridge"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 9
-	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "sZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
 /area/station/cargo/warehouse)
 "ta" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1897,15 +2094,13 @@
 /obj/effect/turf_decal/stripes{
 	dir = 1
 	},
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "td" = (
-/obj/effect/spawner/structure/window/reinforced/shuttle,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "ospreybridge"
 	},
-/obj/structure/grille,
+/obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/station/command/bridge)
 "te" = (
@@ -1926,11 +2121,14 @@
 /obj/structure/sign/nanotrasen{
 	pixel_y = 32
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "tr" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/carpet/royalblue,
@@ -1947,10 +2145,10 @@
 /obj/effect/landmark/start/janitor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "tO" = (
-/obj/effect/turf_decal/tile/neutral/diagonal_edge,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
@@ -1958,12 +2156,17 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "tV" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/station/cargo/miningoffice)
 "tW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/station/engineering/atmos)
 "tX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange,
@@ -1973,23 +2176,19 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "ug" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
-/turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
-"ui" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/item/radio/intercom/directional/east,
+/obj/machinery/computer/cargo/express{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple,
+/obj/structure/sign/poster/official/random/directional/south,
+/turf/open/floor/wood,
+/area/station/cargo/warehouse)
+"ui" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Laboratory"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/purple/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "un" = (
@@ -2001,22 +2200,8 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "up" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/item/storage/box/gloves{
-	pixel_x = -6;
-	pixel_y = 8
-	},
-/obj/item/storage/box/rndboards{
-	desc = "A box containing boards for research equipment.";
-	name = "research equipment box";
-	pixel_x = 3;
-	pixel_y = -5
-	},
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/white,
-/area/station/science/research)
+/turf/open/floor/catwalk_floor/iron,
+/area/station/hallway/primary/aft)
 "ut" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -2036,23 +2221,22 @@
 "uE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/machinery/vending/wardrobe/science_wardrobe,
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "uH" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/structure/filingcabinet,
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/machinery/status_display/shuttle{
 	pixel_x = 32
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/dark_blue/anticorner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 8
+	},
 /area/station/command/bridge)
 "uP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
@@ -2062,27 +2246,43 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"uW" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "uY" = (
 /obj/effect/decal/cleanable/oil/streak,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "uZ" = (
-/obj/structure/filingcabinet/chestdrawer,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/station/science/research)
 "va" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering"
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2095,20 +2295,19 @@
 	name = "Cargo Bay"
 	},
 /obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/station/cargo/office)
 "vm" = (
 /obj/structure/table,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
 /obj/item/mmi/posibrain,
+/obj/effect/turf_decal/siding/red{
+	dir = 10
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "vo" = (
@@ -2123,7 +2322,6 @@
 /area/station/hallway/primary/aft)
 "vp" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/structure/grille,
 /turf/open/floor/plating,
 /area/station/command/bridge)
 "vv" = (
@@ -2133,9 +2331,7 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/machinery/newscaster/directional/north{
-	dir = 1
-	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "vB" = (
@@ -2145,27 +2341,44 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
+/obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "vD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "vN" = (
-/obj/effect/turf_decal/stripes{
-	dir = 1
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark/filled/warning{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
+"vQ" = (
+/obj/structure/sign/nanotrasen{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "vS" = (
 /obj/machinery/atmospherics/components/tank/plasma{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/warning,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes,
+/turf/open/floor/plating,
 /area/station/engineering/atmos)
 "vT" = (
 /obj/structure/cable,
@@ -2181,36 +2394,37 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "vW" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
+/obj/structure/sign/poster/official/random/directional/west,
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/warehouse)
 "we" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/modular_computer/console/preset/id,
+/obj/effect/turf_decal/tile/dark_blue/half{
 	dir = 1
 	},
-/obj/machinery/modular_computer/console/preset/id,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
 /area/station/command/bridge)
 "wi" = (
-/obj/structure/chair{
+/obj/structure/chair/sofa/bench/left{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral/diagonal_edge,
-/obj/effect/turf_decal/tile/blue/anticorner{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
+/turf/open/floor/wood,
 /area/station/medical/medbay/lobby)
 "wj" = (
 /obj/effect/turf_decal/trimline/neutral/warning,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/vending/wardrobe/cargo_wardrobe,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "wl" = (
@@ -2219,43 +2433,61 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "wo" = (
-/obj/machinery/ore_silo,
-/obj/effect/turf_decal/trimline/neutral/warning,
-/obj/item/multitool,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "wt" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/turf/open/floor/circuit/off,
+/area/station/science/robotics/lab)
 "wv" = (
-/obj/effect/turf_decal/tile/neutral/diagonal_edge,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "ww" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/suit_storage_unit/engine,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth_large,
+/area/station/engineering/main)
+"wA" = (
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/grimy,
-/area/station/commons/dorms)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
+"wI" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/science/robotics/lab)
 "wP" = (
 /obj/machinery/suit_storage_unit/standard_unit,
-/obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /obj/machinery/status_display/shuttle{
 	pixel_x = 32
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
 /area/station/hallway/primary/port)
 "wV" = (
 /obj/structure/cable,
@@ -2265,18 +2497,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
+/obj/structure/sign/poster/official/random/directional/west,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "wW" = (
-/obj/machinery/disposal/bin,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/trunk{
-	dir = 2
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "wY" = (
@@ -2294,6 +2521,7 @@
 /area/station/engineering/main)
 "xi" = (
 /obj/structure/closet/emcloset,
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "xw" = (
@@ -2303,41 +2531,28 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "xx" = (
-/obj/effect/turf_decal/stripes{
-	dir = 4
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/cargo/warehouse)
 "xM" = (
-/obj/effect/turf_decal/tile/neutral/diagonal_edge,
-/obj/effect/turf_decal/tile/blue/anticorner{
-	dir = 9
-	},
 /obj/structure/cable,
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=canteen";
 	location = "med"
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/wood,
 /area/station/medical/medbay/lobby)
 "xV" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/structure/chair/sofa/left,
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "yj" = (
-/obj/effect/turf_decal/tile/neutral/diagonal_edge,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/wood,
 /area/station/medical/medbay/lobby)
 "yB" = (
 /obj/structure/cable,
@@ -2357,17 +2572,10 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/port)
 "yV" = (
-/obj/structure/frame/machine,
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/siding/thinplating_new/light,
+/turf/open/floor/iron/dark,
 /area/station/science/research)
 "yZ" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/structure/table/reinforced,
 /obj/machinery/fax{
 	name = "Osprey Fax Machine";
@@ -2376,12 +2584,14 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/dark_blue/anticorner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_corner,
 /area/station/command/bridge)
 "zb" = (
-/obj/structure/closet/secure_closet/quartermaster,
-/turf/open/floor/iron,
-/area/station/cargo/office)
+/turf/open/floor/iron/dark/textured,
+/area/station/engineering/main)
 "zh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2397,6 +2607,7 @@
 /obj/machinery/airalarm/directional/south,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "zm" = (
@@ -2407,19 +2618,26 @@
 	pixel_x = 24;
 	pixel_y = 5
 	},
-/obj/machinery/computer/rdconsole{
-	dir = 8
+/obj/item/radio/intercom/directional/east{
+	pixel_y = -9
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"zs" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor/iron,
+/area/station/hallway/primary/aft)
 "zv" = (
-/obj/effect/turf_decal/tile/neutral/diagonal_edge,
-/obj/effect/turf_decal/tile/blue/anticorner{
-	dir = 10
+/obj/effect/turf_decal/stripes{
+	dir = 8
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/smooth,
+/area/station/cargo/warehouse)
 "zz" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 32
@@ -2430,21 +2648,24 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "zF" = (
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
+/obj/structure/closet/secure_closet/quartermaster,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/carpet/orange,
+/area/station/command/heads_quarters/qm)
 "zI" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/station/science/robotics/lab)
 "zJ" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "zL" = (
 /obj/machinery/suit_storage_unit/standard_unit,
-/obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
@@ -2455,7 +2676,6 @@
 /area/station/hallway/primary/starboard)
 "zQ" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/structure/grille,
 /turf/open/floor/plating,
 /area/station/service/cafeteria)
 "zW" = (
@@ -2473,60 +2693,69 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "Am" = (
-/obj/effect/turf_decal/stripes{
-	dir = 8
-	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=cargo";
 	location = "rnd"
 	},
-/turf/open/floor/circuit,
+/turf/open/floor/catwalk_floor/iron_white,
 /area/station/science/robotics/lab)
 "Av" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/table,
-/obj/item/toy/figure/borg,
+/obj/effect/turf_decal/siding/red,
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/obj/item/toy/mecha/ripley{
+	pixel_y = 21
+	},
+/obj/item/toy/figure/borg{
+	pixel_y = 7;
+	pixel_x = 5
+	},
+/obj/item/toy/figure/roboticist{
+	pixel_x = -1
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "Aw" = (
-/obj/effect/turf_decal/stripes{
-	dir = 1
-	},
-/obj/machinery/power/terminal,
 /obj/machinery/light/small{
 	dir = 4
 	},
 /obj/structure/sign/warning/electric_shock/directional/east,
-/obj/structure/cable,
-/obj/structure/closet/secure_closet/engineering_personal,
-/obj/item/clothing/gloves/color/yellow,
-/turf/open/floor/iron/dark,
+/obj/structure/tank_dispenser,
+/turf/open/floor/iron/smooth_large,
 /area/station/engineering/main)
 "Ax" = (
-/obj/structure/chair/office,
 /obj/effect/landmark/start/scientist,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/chair/stool,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "AD" = (
-/obj/effect/spawner/random/vending/snackvend,
 /obj/machinery/light,
 /obj/machinery/status_display/shuttle{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
+/obj/structure/chair/sofa/left/brown{
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "AH" = (
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/iron/grimy,
-/area/station/commons/dorms)
+/obj/structure/bed/pod,
+/obj/item/bedsheet/qm,
+/obj/structure/curtain/cloth,
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/carpet/orange,
+/area/station/command/heads_quarters/qm)
 "AK" = (
-/obj/machinery/autolathe,
 /obj/effect/turf_decal/trimline/neutral/warning,
 /obj/machinery/button/door{
 	dir = 4;
@@ -2535,7 +2764,12 @@
 	pixel_x = -24;
 	pixel_y = 5
 	},
-/turf/open/floor/iron,
+/obj/machinery/ore_silo,
+/obj/item/multitool{
+	pixel_y = -8;
+	pixel_x = 6
+	},
+/turf/open/floor/iron/textured_large,
 /area/station/cargo/office)
 "AL" = (
 /obj/structure/cable,
@@ -2543,59 +2777,60 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
+/obj/effect/turf_decal/stripes,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "AM" = (
-/obj/effect/turf_decal/stripes{
-	dir = 5
-	},
 /obj/structure/cable,
-/obj/machinery/power/port_gen/pacman/pre_loaded,
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "AP" = (
-/obj/effect/turf_decal/tile/green,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
 	name = "Crew Quarters"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "AW" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
 /turf/open/floor/carpet/blue,
 /area/station/command/bridge)
 "AZ" = (
 /obj/structure/tank_dispenser/oxygen,
-/obj/effect/turf_decal/bot,
 /obj/structure/sign/poster/official/safety_internals{
 	pixel_y = 32
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/starboard)
 "Bl" = (
-/obj/effect/turf_decal/tile/neutral/diagonal_edge,
-/obj/effect/turf_decal/tile/blue/anticorner,
 /obj/machinery/door/airlock/medical/glass{
 	name = "Infirmary"
 	},
-/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "Bq" = (
-/obj/effect/turf_decal/bot,
 /obj/machinery/status_display/shuttle{
 	pixel_y = 32
 	},
 /obj/structure/closet/secure_closet/miner/unlocked,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "Bs" = (
@@ -2611,18 +2846,17 @@
 	dir = 8
 	},
 /obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "BG" = (
-/obj/structure/chair{
+/obj/machinery/airalarm/directional/east,
+/obj/structure/chair/sofa/bench/right{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral/diagonal_edge,
-/obj/effect/turf_decal/tile/blue/anticorner{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron/white,
+/turf/open/floor/wood,
 /area/station/medical/medbay/lobby)
 "BM" = (
 /obj/structure/chair/office{
@@ -2640,24 +2874,28 @@
 /turf/open/floor/plating,
 /area/station/cargo/office)
 "BW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/stairs{
 	dir = 4
 	},
 /area/station/command/bridge)
 "Cb" = (
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/lab)
-"Cd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral/diagonal_edge,
-/obj/effect/turf_decal/tile/blue/anticorner{
-	dir = 6
+/obj/item/trash/can/food,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/science/robotics/lab)
+"Cd" = (
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/cargo/warehouse)
 "Cf" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -2672,9 +2910,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
 /obj/structure/sign/departments/science/alt/directional/west,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron,
 /area/station/science/research)
 "Ch" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
@@ -2682,6 +2919,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "Ck" = (
@@ -2692,16 +2932,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "Cm" = (
-/obj/effect/turf_decal/trimline/purple/filled/warning{
-	dir = 1
-	},
+/obj/effect/turf_decal/bot/left,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "Cn" = (
 /obj/structure/table/reinforced,
-/obj/item/clipboard,
-/obj/item/folder/yellow,
-/obj/item/stamp/qm,
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/window/left/directional/south{
 	dir = 1;
@@ -2727,17 +2962,19 @@
 	},
 /turf/open/floor/plating,
 /area/station/hallway/primary/central)
+"CB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor/iron_white,
+/area/station/science/robotics/lab)
 "CI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
-/turf/open/floor/iron/dark,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/atmos)
 "CQ" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
@@ -2748,22 +2985,25 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
 /obj/structure/sign/departments/cargo/directional/east,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "CR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/station/command/heads_quarters/qm)
 "CW" = (
 /obj/item/trash/cheesie,
-/turf/open/floor/circuit,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/circuit/off,
 /area/station/science/robotics/lab)
 "Dc" = (
-/obj/effect/turf_decal/tile/neutral/diagonal_edge,
 /obj/machinery/iv_drip,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
@@ -2788,9 +3028,9 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/station/cargo/miningoffice)
 "Ds" = (
-/obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/structure/grille,
-/turf/open/floor/plating,
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "Dw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -2807,7 +3047,10 @@
 	},
 /obj/machinery/door/airlock/external/glass,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "DC" = (
 /obj/machinery/atmospherics/components/binary/pump,
@@ -2816,18 +3059,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "DD" = (
-/obj/effect/turf_decal/stripes{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/plating,
 /area/station/maintenance/port)
 "DG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/item/analyzer,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes,
+/turf/open/floor/plating,
 /area/station/engineering/atmos)
 "DI" = (
 /obj/structure/cable,
@@ -2841,21 +3082,55 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"DL" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/circuit/off,
+/area/station/science/robotics/lab)
 "DP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/light/small,
-/turf/open/floor/iron/dark,
+/turf/open/floor/plating,
 /area/station/engineering/atmos)
 "DQ" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/station/service/cafeteria)
+"DR" = (
+/obj/structure/frame/machine,
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark/textured,
+/area/station/science/research)
+"DW" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/catwalk_floor/iron,
+/area/station/hallway/primary/aft)
 "DX" = (
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/station/medical/medbay/lobby)
+"Ea" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/science/robotics/lab)
 "Ed" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/structure/grille,
 /turf/open/floor/plating,
 /area/station/medical/medbay/lobby)
 "Ei" = (
@@ -2869,8 +3144,8 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "ospreybridge"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 6
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
@@ -2880,19 +3155,20 @@
 /obj/item/storage/box/lights/mixed,
 /obj/item/storage/box/lights/mixed,
 /obj/machinery/firealarm/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/service/janitor)
 "Ep" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/structure/table,
+/obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "Er" = (
 /obj/machinery/computer/operating,
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/iron,
 /area/station/medical/medbay/central)
 "Eu" = (
 /obj/structure/cable,
@@ -2919,9 +3195,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "ED" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 6
-	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -2955,25 +3228,27 @@
 "ER" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
-/turf/open/floor/catwalk_floor,
+/turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "ES" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "Fb" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
 /turf/open/floor/iron/grimy,
 /area/station/commons/dorms)
 "Fn" = (
 /obj/structure/chair/office/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral/diagonal_edge,
 /obj/effect/landmark/start/paramedic,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
@@ -2993,21 +3268,30 @@
 	pixel_x = -6
 	},
 /obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/smooth_large,
 /area/station/engineering/main)
 "Fy" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/effect/turf_decal/tile/blue{
-	dir = 6
+/obj/structure/closet/secure_closet/medical3,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
 	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/trimline/dark_blue/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 5
+	},
+/turf/open/floor/iron,
 /area/station/medical/medbay/central)
 "FA" = (
 /obj/machinery/computer/med_data/laptop{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/heavy,
 /obj/structure/table/reinforced/rglass,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "FC" = (
@@ -3018,27 +3302,36 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "FE" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "ospreybridge"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 6
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "FG" = (
-/turf/open/floor/catwalk_floor,
+/turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "FL" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 6
-	},
 /obj/structure/sign/warning/no_smoking/directional/west,
 /obj/structure/closet/secure_closet/medical3,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/station/medical/medbay/central)
 "FO" = (
 /obj/structure/table/reinforced,
@@ -3050,6 +3343,14 @@
 	pixel_y = 5
 	},
 /obj/item/reagent_containers/condiment/enzyme,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/window/spawner/east,
+/obj/machinery/reagentgrinder{
+	pixel_y = 7
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/cafeteria)
 "Gb" = (
@@ -3066,58 +3367,67 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "Gn" = (
 /obj/effect/decal/cleanable/oil/streak,
-/turf/open/floor/circuit,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 8
+	},
+/turf/open/floor/circuit/off,
 /area/station/science/robotics/lab)
 "Gp" = (
 /obj/machinery/suit_storage_unit/standard_unit,
-/obj/effect/turf_decal/bot,
 /obj/machinery/airalarm/directional/west,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/starboard)
 "Gv" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Laboratory"
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/white,
 /area/station/science/research)
 "Gw" = (
-/obj/effect/turf_decal/tile/neutral/diagonal_edge,
-/obj/effect/turf_decal/tile/blue/anticorner{
-	dir = 1
-	},
 /obj/machinery/door/airlock/medical/glass{
 	name = "Infirmary"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "Gy" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 2
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 1
+	},
+/turf/open/floor/circuit/off,
+/area/station/science/robotics/lab)
 "GD" = (
 /turf/closed/wall/mineral/titanium,
 /area/station/medical/medbay/lobby)
 "Hd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/item/radio/intercom/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/starboard)
 "He" = (
@@ -3126,13 +3436,18 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "Hh" = (
-/obj/structure/cable,
 /obj/machinery/light,
+/obj/structure/cable/layer3,
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/oil/streak,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "Hp" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/structure/grille,
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "Hq" = (
@@ -3143,10 +3458,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "Hs" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/structure/chair/sofa/right,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -3158,7 +3469,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "HB" = (
-/obj/structure/tank_dispenser,
+/obj/structure/closet,
+/obj/item/stack/sheet/mineral/plasma/thirty,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
@@ -3167,37 +3479,39 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/station/hallway/primary/aft)
 "HE" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/catwalk_floor/iron,
 /area/station/hallway/primary/aft)
 "HF" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/machinery/computer/rdconsole,
+/obj/effect/turf_decal/tile/dark_blue/half{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
 	},
-/obj/machinery/computer/rdconsole,
-/turf/open/floor/iron/dark,
 /area/station/command/bridge)
+"HP" = (
+/obj/structure/cable/layer3,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/engineering/main)
 "HS" = (
 /turf/closed/wall/mineral/titanium,
 /area/station/service/cafeteria)
 "HV" = (
 /obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "HZ" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/firealarm/directional/north{
-	dir = 1
-	},
 /obj/structure/closet/secure_closet/atmospherics,
-/turf/open/floor/iron/dark,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/plating,
 /area/station/engineering/atmos)
 "Id" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3207,29 +3521,22 @@
 /turf/closed/wall/mineral/titanium,
 /area/station/commons/dorms)
 "Im" = (
-/obj/effect/turf_decal/tile/neutral/diagonal_edge,
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/wood,
 /area/station/medical/medbay/lobby)
 "Ir" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 10
-	},
 /obj/structure/cable,
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
 	name = "Infirmary"
 	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
 "Is" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/dark_blue/diagonal_centre,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "Ix" = (
@@ -3239,12 +3546,15 @@
 	pixel_x = -7
 	},
 /obj/item/clothing/gloves/color/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "IB" = (
 /obj/structure/table,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/item/circuitboard/aicore,
+/obj/effect/turf_decal/siding/red,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "IM" = (
@@ -3260,12 +3570,10 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/starboard)
 "IS" = (
-/obj/effect/turf_decal/stripes{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "IZ" = (
@@ -3276,17 +3584,13 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/smooth_large,
 /area/station/engineering/main)
 "Ji" = (
-/obj/effect/turf_decal/tile/neutral/diagonal_edge,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
+/turf/open/floor/wood,
 /area/station/medical/medbay/lobby)
 "Jk" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
 /obj/structure/chair{
 	dir = 4
 	},
@@ -3299,11 +3603,10 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/brown,
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay"
 	},
-/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron/dark,
 /area/station/cargo/warehouse)
 "Jt" = (
@@ -3315,18 +3618,29 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "Ju" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
 	name = "Infirmary"
 	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"Jx" = (
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/structure/rack,
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "JB" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
@@ -3352,17 +3666,14 @@
 	dir = 8
 	},
 /mob/living/simple_animal/hostile/lizard/wags_his_tail,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "JF" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/machinery/door/airlock/research/glass{
 	name = "Laboratory"
 	},
-/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/purple/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "JO" = (
@@ -3371,20 +3682,22 @@
 	pixel_x = 2;
 	pixel_y = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/storage/toolbox/electrical{
 	pixel_x = -6
+	},
+/obj/effect/turf_decal/siding/red{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "JQ" = (
 /obj/structure/railing,
 /obj/machinery/holopad,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/white,
 /area/station/command/bridge)
 "JR" = (
 /obj/structure/cable,
@@ -3396,42 +3709,61 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "JS" = (
-/obj/effect/landmark/start/cargo_technician,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/structure/disposalpipe/segment,
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/obj/item/pen{
+	pixel_x = 7
 	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "JU" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/structure/grille,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "JV" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/extinguisher_cabinet/directional/south,
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "Kd" = (
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/science/research)
-"Kh" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/obj/item/pen,
+/obj/item/storage/box/gloves{
+	pixel_x = -6;
+	pixel_y = 13
+	},
+/obj/item/storage/box/rndboards{
+	desc = "A box containing boards for research equipment.";
+	name = "research equipment box";
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/siding/thinplating_new/light{
 	dir = 9
 	},
-/obj/machinery/disposal/bin,
+/turf/open/floor/iron/dark/textured,
+/area/station/science/research)
+"Kh" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 2
-	},
+/obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "Kl" = (
@@ -3448,43 +3780,50 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/service/janitor)
 "Ko" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "Kt" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/station/commons/dorms)
 "Ky" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "KE" = (
-/obj/machinery/light{
-	dir = 4
+/obj/structure/table,
+/obj/item/clipboard,
+/obj/item/folder/yellow,
+/obj/item/stamp/qm{
+	pixel_y = 10;
+	pixel_x = 7
 	},
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/qm)
 "KO" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/structure/grille,
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
 "KV" = (
 /obj/machinery/light,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "Lh" = (
@@ -3498,12 +3837,19 @@
 "Lk" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/station/cargo/office)
-"Lq" = (
-/obj/effect/turf_decal/trimline/neutral/warning,
-/obj/machinery/firealarm/directional/east,
-/obj/machinery/computer/cargo/express{
+"Ln" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/science/robotics/lab)
+"Lq" = (
+/obj/machinery/firealarm/directional/east,
+/obj/structure/ore_box,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "Lt" = (
@@ -3527,12 +3873,14 @@
 "LB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/item/wrench,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/station/engineering/atmos)
 "LO" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
-	},
+/obj/structure/sign/poster/official/random/directional/north,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "LP" = (
@@ -3544,20 +3892,17 @@
 /turf/open/floor/plating,
 /area/station/science/research)
 "Mj" = (
-/obj/effect/turf_decal/bot,
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/miner/unlocked,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "Ml" = (
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "Mm" = (
-/obj/effect/turf_decal/stripes{
-	dir = 8
-	},
 /obj/machinery/cryopod,
 /obj/machinery/computer/cryopod{
 	pixel_y = 32
@@ -3565,10 +3910,16 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms)
 "Mn" = (
 /obj/machinery/newscaster/directional/south,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "Mp" = (
@@ -3585,24 +3936,13 @@
 "Ms" = (
 /obj/structure/table/reinforced,
 /obj/structure/extinguisher_cabinet/directional/south,
-/obj/machinery/reagentgrinder{
-	pixel_y = 7
-	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/cafeteria)
 "Mw" = (
-/obj/effect/turf_decal/caution/stand_clear{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/plating,
 /area/station/maintenance/port)
 "Mx" = (
 /obj/structure/chair/office,
@@ -3612,54 +3952,58 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/engineering/main)
 "My" = (
 /obj/structure/railing,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/effect/landmark/start/head_of_personnel,
 /obj/structure/chair/comfy/shuttle{
 	dir = 1;
 	name = "Operations"
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/thinplating_new/dark/end{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/command/bridge)
 "MJ" = (
-/obj/effect/turf_decal/tile/neutral/diagonal_edge,
-/obj/effect/turf_decal/tile/blue/anticorner{
-	dir = 1
-	},
 /obj/effect/landmark/start/medical_doctor,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/dark_blue/warning,
+/obj/effect/turf_decal/siding/thinplating_new/light,
+/turf/open/floor/iron,
 /area/station/medical/medbay/central)
 "MM" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "MO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
-"MQ" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
+/obj/effect/turf_decal/siding/yellow{
+	dir = 1
 	},
+/obj/structure/chair/office/light,
+/obj/effect/landmark/start/quartermaster,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/qm)
+"MQ" = (
+/obj/structure/chair/stool/bar,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "MY" = (
 /obj/machinery/cryopod,
-/obj/effect/turf_decal/stripes{
+/obj/machinery/light/small,
+/obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/machinery/light/small,
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms)
 "Nb" = (
@@ -3667,48 +4011,58 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "Ng" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/computer/communications,
+/obj/effect/turf_decal/tile/dark_blue/half{
 	dir = 1
 	},
-/obj/machinery/computer/communications,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
 /area/station/command/bridge)
+"Nh" = (
+/obj/structure/cable,
+/obj/structure/frame/machine,
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/science/research)
 "Nr" = (
 /obj/structure/table,
 /obj/item/reagent_containers/cup/bucket,
 /obj/item/reagent_containers/spray/cleaner,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "Nx" = (
-/obj/effect/turf_decal/tile/green,
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
 	name = "Crew Quarters"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "NA" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
 /obj/structure/cable,
-/turf/open/floor/catwalk_floor,
+/turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/engineering/main)
+"NG" = (
+/obj/structure/table_frame,
+/obj/effect/turf_decal/tile/red/diagonal_centre,
+/turf/open/floor/iron/white/diagonal,
+/area/station/science/robotics/lab)
 "NP" = (
-/obj/effect/spawner/structure/window/reinforced/shuttle,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "ospreycargo"
 	},
-/obj/structure/grille,
+/obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/station/cargo/office)
 "NU" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
 /obj/machinery/door/airlock{
 	name = "Custodial Office"
 	},
@@ -3729,15 +4083,19 @@
 	pixel_x = -32
 	},
 /obj/machinery/oven,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/window/spawner/north,
+/turf/open/floor/iron/showroomfloor,
 /area/station/service/cafeteria)
 "NY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral/diagonal_edge,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
+/turf/open/floor/wood,
 /area/station/medical/medbay/lobby)
 "Oe" = (
 /obj/structure/cable,
@@ -3758,12 +4116,14 @@
 	dir = 8
 	},
 /obj/structure/table/reinforced,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/turf/open/floor/iron/showroomfloor,
 /area/station/service/cafeteria)
 "Os" = (
-/obj/effect/turf_decal/trimline/brown/filled/warning{
-	dir = 1
-	},
+/obj/effect/turf_decal/bot/right,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "Ov" = (
@@ -3773,18 +4133,12 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/catwalk_floor/iron,
 /area/station/hallway/primary/aft)
 "Ow" = (
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom{
 	pixel_y = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
 	},
 /obj/machinery/button/door{
 	id = "ospreybridge";
@@ -3798,7 +4152,12 @@
 	pixel_x = -6;
 	pixel_y = -3
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/dark_blue/half{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
 /area/station/command/bridge)
 "Ox" = (
 /obj/machinery/door/firedoor,
@@ -3806,38 +4165,39 @@
 /area/station/hallway/primary/aft)
 "OO" = (
 /obj/structure/sink/directional/east,
-/obj/effect/turf_decal/tile/blue{
-	dir = 6
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/dark_blue/warning,
+/obj/effect/turf_decal/siding/thinplating_new/light,
+/obj/structure/table/glass,
+/obj/item/storage/backpack/duffelbag/med/surgery{
+	pixel_x = -3;
+	pixel_y = 13
 	},
-/turf/open/floor/iron/white,
+/obj/item/clothing/gloves/color/latex,
+/turf/open/floor/iron,
 /area/station/medical/medbay/central)
 "OR" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
 	name = "Canteen"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/service/cafeteria)
 "OU" = (
-/obj/effect/turf_decal/stripes{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/structure/cable/layer3,
+/obj/effect/turf_decal/stripes,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "OV" = (
@@ -3846,13 +4206,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/cargo/office)
+"Pf" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/circuit/off,
+/area/station/science/robotics/lab)
 "Ph" = (
 /obj/structure/table/wood,
 /obj/item/folder,
 /obj/item/pen,
-/obj/machinery/newscaster/directional/north{
-	dir = 1
-	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "Pm" = (
@@ -3896,6 +4262,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "PU" = (
@@ -3922,27 +4291,25 @@
 /obj/machinery/door/window/left/directional/east,
 /obj/structure/sign/warning/deathsposal/directional/north,
 /obj/item/trash/can/food/beans,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/service/janitor)
 "Qq" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/brown,
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay"
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron/dark,
 /area/station/cargo/warehouse)
 "Qu" = (
 /obj/machinery/computer/atmos_alert{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/warning,
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -3960,10 +4327,14 @@
 /obj/machinery/firealarm/directional/west{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "QB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "QH" = (
@@ -3979,6 +4350,7 @@
 /obj/machinery/conveyor_switch/oneway{
 	id = "osprey_conveyor"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/service/janitor)
 "QJ" = (
@@ -3990,7 +4362,7 @@
 	name = "Air to Distro"
 	},
 /obj/structure/fireaxecabinet/directional/west,
-/turf/open/floor/iron/dark,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/atmos)
 "QT" = (
 /obj/machinery/light{
@@ -4002,16 +4374,19 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/station/medical/medbay/central)
 "QV" = (
 /obj/structure/tank_dispenser/oxygen,
-/obj/effect/turf_decal/bot,
 /obj/structure/sign/poster/official/safety_internals{
 	pixel_y = 32
 	},
 /obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron/dark,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
 /area/station/hallway/primary/port)
 "Rd" = (
 /obj/machinery/door/airlock/maintenance/external,
@@ -4019,7 +4394,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/port)
 "Rg" = (
@@ -4029,19 +4403,27 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "Rm" = (
-/obj/effect/turf_decal/stripes,
-/turf/open/floor/plating,
-/area/station/engineering/main)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/cargo/warehouse)
 "Rv" = (
 /obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/warehouse)
 "RC" = (
-/obj/structure/cable,
 /obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/smooth,
 /area/station/cargo/warehouse)
 "RE" = (
 /obj/machinery/door/airlock{
@@ -4049,16 +4431,19 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/iron/grimy,
 /area/station/commons/dorms)
 "RG" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/station/science/research)
-"RZ" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
+"RO" = (
+/obj/machinery/atmospherics/components/tank/air{
+	dir = 8
 	},
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
+"RZ" = (
 /obj/structure/dresser,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/grimy,
@@ -4068,9 +4453,12 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/station/service/janitor)
 "Sc" = (
+/obj/structure/closet/crate{
+	name = "food crate"
+	},
+/obj/effect/spawner/random/maintenance/three,
 /obj/effect/turf_decal/bot,
-/obj/structure/ore_box,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth,
 /area/station/cargo/warehouse)
 "Sl" = (
 /obj/structure/closet/crate/coffin,
@@ -4078,6 +4466,9 @@
 /area/station/service/janitor)
 "Sr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "Ss" = (
@@ -4095,27 +4486,42 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/service/janitor)
+"SK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "SN" = (
 /obj/machinery/suit_storage_unit/standard_unit,
-/obj/effect/turf_decal/bot,
 /obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron/dark,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
 /area/station/hallway/primary/port)
 "SO" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
 	pixel_x = -6
 	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "SP" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/station/service/cafeteria)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/station/engineering/main)
 "SQ" = (
 /obj/structure/cable,
 /obj/structure/window/reinforced/plasma/spawner,
@@ -4140,8 +4546,16 @@
 /area/station/maintenance/port)
 "SZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/service/janitor)
+"Tc" = (
+/obj/machinery/vending/wardrobe/cargo_wardrobe,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
+/area/station/cargo/office)
 "Td" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -4161,31 +4575,32 @@
 /area/station/cargo/office)
 "Tl" = (
 /obj/structure/table/reinforced,
-/obj/machinery/microwave,
+/obj/machinery/microwave{
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/cafeteria)
 "Tp" = (
-/obj/effect/turf_decal/stripes{
-	dir = 8
-	},
+/obj/item/wrench,
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "Tt" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/bot,
 /obj/structure/sign/warning/no_smoking/directional/west,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "Tu" = (
 /obj/structure/window/reinforced/plasma/spawner/north,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
+"Tv" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningoffice)
 "Tw" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
@@ -4193,25 +4608,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral/diagonal_edge,
-/turf/open/floor/iron/white,
+/turf/open/floor/wood,
 /area/station/medical/medbay/lobby)
 "TB" = (
-/obj/effect/decal/cleanable/oil/streak,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/bot_white/left,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "TM" = (
 /obj/structure/chair{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral/diagonal_edge,
-/obj/effect/turf_decal/tile/blue/anticorner{
-	dir = 4
-	},
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
+/turf/open/floor/wood,
 /area/station/medical/medbay/lobby)
 "TU" = (
 /obj/structure/toilet{
@@ -4220,6 +4629,9 @@
 /obj/structure/curtain,
 /obj/structure/window/reinforced/tinted/frosted,
 /obj/effect/landmark/start/assistant,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms)
 "TV" = (
@@ -4246,26 +4658,24 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/station/command/bridge)
 "Ui" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass,
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/station/hallway/primary/port)
 "Uj" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "Uk" = (
@@ -4277,15 +4687,13 @@
 	pixel_x = -24
 	},
 /obj/structure/closet/secure_closet/freezer/kitchen,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/cafeteria)
 "Ur" = (
 /turf/closed/wall/mineral/titanium,
 /area/station/medical/medbay/central)
 "Uv" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -4300,30 +4708,40 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms)
 "UE" = (
-/obj/effect/turf_decal/stripes{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/cargo/warehouse)
+"UH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/service/cafeteria)
 "US" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "UT" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/cafeteria)
 "UU" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/station/hallway/primary/port)
 "UY" = (
-/obj/effect/turf_decal/tile/neutral/diagonal_edge,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "Va" = (
@@ -4332,7 +4750,7 @@
 	dir = 4
 	},
 /obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron/dark,
+/turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "Vl" = (
 /obj/machinery/washing_machine,
@@ -4342,46 +4760,49 @@
 /area/station/commons/dorms)
 "Vp" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/siding/wood,
+/obj/structure/chair/stool/bar,
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "Vr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral/diagonal_edge,
-/obj/effect/turf_decal/tile/blue/anticorner{
-	dir = 5
+/obj/effect/turf_decal/stripes{
+	dir = 1
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/closet/emcloset/anchored,
+/turf/open/floor/plating/airless,
+/area/station/cargo/miningoffice)
 "Vu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/machinery/light/small{
 	dir = 1
 	},
 /obj/structure/sign/warning/no_smoking/directional/north,
-/turf/open/floor/iron/dark,
+/turf/open/floor/plating,
 /area/station/engineering/atmos)
 "Vz" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
-/obj/effect/spawner/random/vending/colavend,
 /obj/machinery/airalarm/directional/south,
+/obj/structure/chair/sofa/right/brown{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
+"VD" = (
+/obj/structure/aquarium/prefilled,
+/obj/item/fish_feed{
+	pixel_y = -9;
+	pixel_x = 8
+	},
+/turf/open/floor/wood,
+/area/station/medical/medbay/lobby)
 "VF" = (
-/obj/structure/chair/stool/bar,
-/obj/effect/turf_decal/siding/wood,
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "VM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -4414,6 +4835,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "Wh" = (
@@ -4423,6 +4847,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"WA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/cargo/warehouse)
 "WJ" = (
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
@@ -4434,8 +4863,13 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 8
+	},
 /obj/structure/frame/machine,
+/obj/structure/railing{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "WW" = (
@@ -4462,6 +4896,10 @@
 /obj/machinery/door/window/right/directional/east{
 	name = "Kitchen"
 	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/cafeteria)
 "Xi" = (
@@ -4472,37 +4910,52 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"Xl" = (
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/engineering/main)
 "Xm" = (
 /obj/machinery/medical_kiosk,
-/obj/effect/turf_decal/tile/neutral/diagonal_edge,
-/obj/effect/turf_decal/tile/blue/anticorner{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron/white,
+/turf/open/floor/wood,
 /area/station/medical/medbay/lobby)
 "Xp" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/crate/internals,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/obj/effect/turf_decal/siding/yellow{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/west,
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/qm)
+"Xt" = (
+/obj/machinery/atmospherics/components/tank/plasma{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "XB" = (
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
 /obj/machinery/recharger,
 /obj/structure/table/reinforced,
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
 /turf/open/floor/wood,
 /area/station/command/bridge)
 "XE" = (
 /obj/structure/reagent_dispensers,
 /obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "XH" = (
@@ -4513,38 +4966,38 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "XL" = (
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
 /turf/open/floor/wood,
 /area/station/command/bridge)
 "XO" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "XR" = (
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "XS" = (
 /obj/structure/closet/secure_closet/captains{
 	icon_state = "cap";
@@ -4566,28 +5019,22 @@
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "Ym" = (
-/obj/effect/turf_decal/stripes{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/station/engineering/main)
+/turf/closed/wall/mineral/titanium,
+/area/station/command/heads_quarters/qm)
 "Yn" = (
-/obj/effect/turf_decal/tile/neutral/diagonal_edge,
-/obj/effect/turf_decal/tile/blue/anticorner{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/table/glass,
-/obj/item/storage/backpack/duffelbag/med/surgery{
-	pixel_x = -3;
-	pixel_y = 13
-	},
-/obj/item/clothing/gloves/color/latex,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/dark_blue/warning,
+/obj/effect/turf_decal/siding/thinplating_new/light,
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/iron,
 /area/station/medical/medbay/central)
 "Yo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
@@ -4600,7 +5047,8 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/turf/open/floor/catwalk_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth_large,
 /area/station/engineering/main)
 "YK" = (
 /obj/structure/cable,
@@ -4608,7 +5056,7 @@
 /area/station/maintenance/port)
 "YS" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/structure/grille,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/science/research)
 "Za" = (
@@ -4628,6 +5076,9 @@
 /obj/structure/curtain,
 /obj/item/soap/nanotrasen,
 /obj/item/bikehorn/rubberducky,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms)
 "Zt" = (
@@ -4638,35 +5089,39 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "ZD" = (
 /obj/structure/closet/firecloset/full,
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "ZF" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = 6
-	},
-/obj/item/pen{
-	pixel_x = -7
-	},
-/turf/open/floor/iron/white,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/science/research)
 "ZK" = (
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "ZN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "ZU" = (
 /obj/structure/cable,
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "ZV" = (
@@ -4827,7 +5282,7 @@ XU
 XU
 cq
 Jk
-SP
+rj
 VF
 aJ
 cu
@@ -4885,9 +5340,9 @@ XU
 XU
 cq
 Ep
-rj
-VF
-aJ
+Ky
+MQ
+UH
 cu
 cu
 Ms
@@ -4943,9 +5398,9 @@ XU
 XU
 cq
 jV
-Ky
+rj
 fR
-aJ
+UH
 cu
 UT
 jy
@@ -5013,10 +5468,10 @@ NU
 Sb
 pT
 pT
-UU
+pT
 sl
 mR
-yU
+sr
 rM
 zz
 il
@@ -5068,11 +5523,11 @@ DQ
 iO
 QA
 uP
-fx
+fS
 gm
 fS
 Rd
-yU
+sr
 kW
 yU
 rM
@@ -5118,17 +5573,17 @@ XU
 XU
 DQ
 jA
-MQ
+rj
 pU
-MQ
+rj
 Vz
 DQ
 ox
 Zt
 nl
 bs
+jU
 PY
-nI
 UU
 QV
 wP
@@ -5149,7 +5604,7 @@ XU
 hw
 zI
 jN
-Cb
+NG
 mV
 oO
 pi
@@ -5175,7 +5630,7 @@ XU
 bP
 sn
 pO
-Ds
+pO
 sG
 OR
 zQ
@@ -5207,8 +5662,8 @@ hw
 Dp
 zI
 gM
-jn
-jn
+eG
+Gy
 Gn
 CW
 lT
@@ -5231,12 +5686,12 @@ XU
 XU
 XU
 sn
-HV
+Ds
 Hv
-WJ
+Ox
 WJ
 aK
-Gy
+EL
 EL
 WW
 EL
@@ -5290,12 +5745,12 @@ XU
 Ur
 pO
 ow
-WJ
-WJ
-WJ
+kw
+Ox
+up
 Ov
 HE
-hk
+zs
 Ev
 hk
 XH
@@ -5323,13 +5778,13 @@ Cm
 aw
 KO
 qO
-jn
+Pf
 JO
 IB
-jn
+DL
 rX
 RG
-RG
+cm
 RG
 LP
 RG
@@ -5348,8 +5803,8 @@ Do
 Do
 pO
 ZK
-WJ
-bP
+kw
+qn
 qn
 qn
 qn
@@ -5374,20 +5829,20 @@ XU
 (13,1,1) = {"
 XU
 XU
-XU
+Vr
 ap
 mQ
-Cm
+aw
 fE
 KO
-Cb
-jn
+Jx
+wt
 rF
 Av
 qc
 qg
 YS
-up
+wW
 uE
 wW
 wV
@@ -5413,10 +5868,10 @@ hC
 zW
 Lh
 sB
-ZK
+uW
 BC
 xh
-FG
+SP
 KV
 qf
 qf
@@ -5432,27 +5887,27 @@ XU
 (14,1,1) = {"
 XU
 XU
-XU
+tV
 jh
-vN
 aw
+dr
 zJ
 ui
 lY
 qT
 Am
 qT
-qT
-lY
+CB
+wI
 gc
 Rg
 EO
 Kd
-Kd
+Nh
 az
 Ax
 JB
-pE
+XR
 Ac
 tf
 Do
@@ -5463,8 +5918,8 @@ Dc
 tO
 ab
 pO
-WJ
-WJ
+it
+kw
 td
 Ng
 Is
@@ -5472,10 +5927,10 @@ AW
 VO
 sB
 tj
-vo
-Hp
-FG
-NA
+SK
+xh
+dW
+aC
 ml
 ep
 Tp
@@ -5490,17 +5945,17 @@ XU
 (15,1,1) = {"
 XU
 XU
-XU
+tV
 jh
-vN
-Xb
-zJ
+aw
+gC
+aw
 JF
-kE
-Cb
+Ea
+oT
 ea
 Cb
-Cb
+Ln
 kE
 Gv
 PU
@@ -5533,11 +5988,11 @@ ZN
 vo
 Hp
 FG
-aC
-tc
+HP
+Xl
 qa
+mX
 qa
-Rm
 qf
 XU
 XU
@@ -5548,10 +6003,10 @@ XU
 (16,1,1) = {"
 XU
 XU
-XU
+tV
 jh
 vN
-fI
+vN
 hz
 yG
 yG
@@ -5563,9 +6018,9 @@ yG
 RG
 RG
 RG
-RG
-RG
-RG
+nI
+DR
+rJ
 RG
 RG
 Hq
@@ -5578,7 +6033,7 @@ iw
 FA
 Gw
 Bl
-HD
+pO
 sN
 WJ
 td
@@ -5593,9 +6048,9 @@ Hp
 FG
 aC
 aB
-Bs
-Bs
-Rm
+qa
+qa
+qa
 qf
 XU
 XU
@@ -5606,24 +6061,24 @@ XU
 (17,1,1) = {"
 XU
 XU
-XU
+tV
 jh
-vN
+aw
 TB
-VM
+Tv
 Jn
 Rv
 vW
-ln
-ln
-ln
+Cd
+Cd
+sK
 Rv
 vj
 ut
 fq
 wo
-it
-zb
+wo
+wo
 AK
 NP
 Sr
@@ -5632,8 +6087,8 @@ pr
 af
 ok
 TA
-Cd
-Vr
+TA
+TA
 NY
 iy
 Ju
@@ -5649,11 +6104,11 @@ QB
 vo
 Hp
 FG
-aC
+HP
 tc
 qa
+gu
 qa
-Rm
 qf
 XU
 XU
@@ -5664,23 +6119,23 @@ XU
 (18,1,1) = {"
 XU
 XU
-XU
+tV
 jh
-vN
 aw
+Xb
 VM
 Qq
-UE
+WA
 UE
 qC
 xx
-xx
-xx
+Rm
+ad
 mv
 OV
 uY
 gD
-cm
+gD
 ES
 fD
 Cn
@@ -5690,12 +6145,12 @@ yB
 Ir
 Ji
 eB
-zv
+Ji
 xM
 Im
 yj
 jS
-JR
+eA
 gX
 td
 HF
@@ -5703,15 +6158,15 @@ Is
 tr
 ae
 sB
-tj
-vo
-Hp
-FG
-NA
+vQ
+ci
+xh
+zb
+aC
 AM
 sw
-jU
-Ym
+Bs
+qa
 qf
 XU
 XU
@@ -5722,18 +6177,18 @@ XU
 (19,1,1) = {"
 XU
 XU
-XU
+Vr
 ap
 Mj
-Os
+aw
 aw
 iq
-ln
-ln
-MO
 sZ
-ln
-tV
+sZ
+sZ
+sZ
+zv
+sZ
 ip
 wj
 mJ
@@ -5745,11 +6200,11 @@ CQ
 Cr
 gB
 Di
-DX
+sf
 BG
 wi
 Xm
-wi
+VD
 TM
 jT
 HD
@@ -5762,7 +6217,7 @@ dI
 XS
 sB
 JV
-vo
+ci
 xh
 ER
 Hh
@@ -5784,16 +6239,16 @@ Dp
 Dp
 Bq
 Os
-og
+aw
 JU
-ln
+hN
 Sc
 nO
 oP
 qe
 RC
 Lk
-Lk
+Tc
 Lk
 BR
 Lk
@@ -5813,7 +6268,7 @@ sf
 pO
 oI
 gX
-bP
+qn
 qn
 qn
 qn
@@ -5843,12 +6298,12 @@ Dp
 hw
 dj
 Lq
-yG
-oR
-ln
 CR
-wt
-ln
+oR
+CR
+CR
+CR
+qe
 sM
 yG
 Lk
@@ -5870,14 +6325,14 @@ XU
 GD
 pO
 cj
+wA
 eY
-eY
-eY
+DW
 mo
 rW
-eY
-eY
-eY
+DW
+og
+ps
 FC
 va
 gy
@@ -5901,7 +6356,7 @@ XU
 hw
 hw
 Dp
-yG
+CR
 zF
 Xp
 oK
@@ -5932,7 +6387,7 @@ WJ
 WJ
 WJ
 JR
-Ox
+WJ
 WJ
 cr
 WJ
@@ -5941,7 +6396,7 @@ aG
 HB
 jg
 Aw
-eq
+ww
 qf
 lU
 XU
@@ -5959,11 +6414,11 @@ XU
 XU
 XU
 hw
-yG
-ln
-ln
+CR
+AH
+MO
 KE
-XR
+CR
 ln
 ug
 yG
@@ -5987,7 +6442,7 @@ XU
 bP
 sn
 mE
-pJ
+mE
 Nx
 AP
 pJ
@@ -6017,11 +6472,11 @@ XU
 XU
 XU
 XU
-ja
-yG
-ki
-yG
-yG
+Ym
+CR
+fx
+CR
+CR
 ki
 yG
 ja
@@ -6055,8 +6510,8 @@ kf
 cg
 lq
 nn
+eo
 Ml
-ps
 ao
 AZ
 zL
@@ -6111,8 +6566,8 @@ Ph
 If
 WK
 Gf
-cg
-cg
+fZ
+fZ
 Ch
 fZ
 md
@@ -6173,10 +6628,10 @@ bQ
 qq
 qq
 qq
-ao
+qq
 Hd
 mI
-IN
+fI
 PK
 cc
 oy
@@ -6278,7 +6733,7 @@ XU
 te
 xi
 hM
-AH
+Fb
 mE
 TU
 Zs
@@ -6335,7 +6790,7 @@ XU
 XU
 te
 ZD
-ww
+Kt
 Kt
 RE
 UC
@@ -6399,12 +6854,12 @@ mE
 qy
 Vl
 If
-vS
+Xt
 vS
 PW
 Qu
 iS
-iS
+RO
 PK
 kJ
 sH

--- a/_maps/voidcrew/ship_osprey.dmm
+++ b/_maps/voidcrew/ship_osprey.dmm
@@ -4,12 +4,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"ad" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
 "ae" = (
 /obj/machinery/light/small,
 /obj/structure/curtain/cloth/fancy,
@@ -104,13 +98,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
+/obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/machinery/griddle,
-/obj/structure/window/spawner/north,
-/obj/structure/window/spawner/east,
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/cafeteria)
 "aK" = (
@@ -242,19 +234,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"ci" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
 "cj" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -269,13 +248,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "cm" = (
-/obj/machinery/airalarm/directional/west,
-/obj/machinery/vending/wardrobe/science_wardrobe,
-/obj/effect/turf_decal/siding/thinplating_new/light{
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/station/science/research)
+/turf/open/floor/circuit/off,
+/area/station/science/robotics/lab)
 "cq" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /obj/machinery/door/poddoor/shutters{
@@ -341,6 +322,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/medical/medbay/central)
+"cP" = (
+/obj/structure/sign/nanotrasen{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "cS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/cable,
@@ -396,10 +384,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
-"dr" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark,
-/area/station/cargo/miningoffice)
+"dn" = (
+/obj/structure/bed/pod,
+/obj/item/bedsheet/qm,
+/obj/structure/curtain/cloth,
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/carpet/orange,
+/area/station/command/heads_quarters/qm)
 "dy" = (
 /obj/machinery/light,
 /obj/item/radio/intercom/directional/south,
@@ -431,10 +425,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/command/bridge)
-"dW" = (
-/obj/effect/decal/cleanable/oil,
-/turf/open/floor/iron/dark/textured,
-/area/station/engineering/main)
 "ea" = (
 /obj/structure/sign/poster/official/random/directional/east,
 /obj/effect/turf_decal/trimline/purple/line{
@@ -476,32 +466,16 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/service/janitor)
-"eo" = (
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "ep" = (
 /obj/structure/cable,
 /obj/machinery/power/port_gen/pacman/super,
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "eq" = (
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable,
+/obj/machinery/suit_storage_unit/engine,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/main)
-"eA" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
 "eB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -509,11 +483,13 @@
 	},
 /turf/open/floor/wood,
 /area/station/medical/medbay/lobby)
-"eG" = (
-/obj/structure/chair/office,
+"eH" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 1
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/dark/diagonal_centre,
-/turf/open/floor/iron/white/diagonal,
+/turf/open/floor/circuit/off,
 /area/station/science/robotics/lab)
 "eM" = (
 /obj/machinery/computer/atmos_alert{
@@ -568,13 +544,15 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "fx" = (
-/obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor/shutters{
-	id = "ospreywindows";
-	name = "Blast Shutters"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/command/heads_quarters/qm)
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "fD" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/start/cargo_technician,
@@ -590,8 +568,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/hallway/primary/starboard)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark,
+/area/station/hallway/primary/port)
 "fL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -599,6 +578,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"fO" = (
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "fR" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=bridge";
@@ -609,15 +592,11 @@
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "fS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/cargo/warehouse)
 "fU" = (
 /obj/machinery/power/shuttle_engine/ship/fueled/plasma{
 	dir = 1
@@ -714,10 +693,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"gC" = (
-/obj/effect/turf_decal/bot_white/right,
-/turf/open/floor/iron/dark,
-/area/station/cargo/miningoffice)
 "gD" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -731,6 +706,12 @@
 /obj/structure/sign/warning/vacuum/external,
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/station/maintenance/starboard)
+"gI" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "gM" = (
 /obj/item/wallframe/camera,
 /obj/item/wallframe/camera,
@@ -768,6 +749,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"gY" = (
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "hk" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -852,42 +837,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/station/commons/dorms)
-"hN" = (
-/obj/item/food/canned/beans{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/food/canned/beans{
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/obj/item/food/canned/beans{
-	pixel_x = -2
-	},
-/obj/item/reagent_containers/cup/glass/waterbottle/large{
-	pixel_x = 5
-	},
-/obj/item/reagent_containers/cup/glass/waterbottle/large{
-	pixel_x = 1;
-	pixel_y = -3
-	},
-/obj/item/reagent_containers/cup/glass/waterbottle/large{
-	pixel_x = 8;
-	pixel_y = -3
-	},
-/obj/structure/closet/crate{
-	name = "food crate"
-	},
-/obj/item/storage/cans/sixbeer,
-/obj/item/food/rationpack,
-/obj/item/food/rationpack,
-/obj/item/food/rationpack,
-/obj/item/food/rationpack,
-/obj/item/food/rationpack,
-/obj/item/food/rationpack,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/smooth,
-/area/station/cargo/warehouse)
 "il" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable,
@@ -903,9 +852,17 @@
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "it" = (
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 1
+	},
+/turf/open/floor/circuit/off,
+/area/station/science/robotics/lab)
 "iw" = (
 /obj/item/paper_bin{
 	pixel_x = 6
@@ -1016,11 +973,10 @@
 /turf/open/floor/plating,
 /area/station/cargo/miningoffice)
 "jn" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/thinplating_new,
-/turf/open/floor/circuit/off,
+/obj/structure/chair/office,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/dark/diagonal_centre,
+/turf/open/floor/iron/white/diagonal,
 /area/station/science/robotics/lab)
 "js" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -1091,11 +1047,9 @@
 /turf/open/floor/wood,
 /area/station/medical/medbay/lobby)
 "jU" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/iron/dark/textured,
+/area/station/engineering/main)
 "jV" = (
 /obj/structure/chair{
 	dir = 8
@@ -1136,6 +1090,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/commons/dorms)
+"km" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor/iron,
+/area/station/hallway/primary/aft)
 "kp" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
 	dir = 4
@@ -1150,16 +1110,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/main)
-"kw" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
 "kE" = (
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 4
 	},
@@ -1206,6 +1161,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/service/janitor)
+"le" = (
+/obj/machinery/vending/wardrobe/cargo_wardrobe,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
+/area/station/cargo/office)
 "lf" = (
 /obj/machinery/suit_storage_unit/atmos,
 /obj/machinery/airalarm/directional/south,
@@ -1240,11 +1202,40 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "ln" = (
-/obj/structure/frame/computer{
-	anchored = 1;
-	dir = 8
+/obj/item/food/canned/beans{
+	pixel_x = -5;
+	pixel_y = 3
 	},
-/turf/open/floor/wood,
+/obj/item/food/canned/beans{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/food/canned/beans{
+	pixel_x = -2
+	},
+/obj/item/reagent_containers/cup/glass/waterbottle/large{
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/cup/glass/waterbottle/large{
+	pixel_x = 1;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/cup/glass/waterbottle/large{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/obj/structure/closet/crate{
+	name = "food crate"
+	},
+/obj/item/storage/cans/sixbeer,
+/obj/item/food/rationpack,
+/obj/item/food/rationpack,
+/obj/item/food/rationpack,
+/obj/item/food/rationpack,
+/obj/item/food/rationpack,
+/obj/item/food/rationpack,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/smooth,
 /area/station/cargo/warehouse)
 "lq" = (
 /obj/machinery/light{
@@ -1281,7 +1272,9 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "lY" = (
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "md" = (
@@ -1350,6 +1343,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"mr" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/cargo/warehouse)
 "mv" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay"
@@ -1387,6 +1385,24 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/iron,
 /area/station/cargo/office)
+"mL" = (
+/obj/item/stack/pipe_cleaner_coil/cut/yellow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/engineering/main)
+"mO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "mQ" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/light{
@@ -1415,11 +1431,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
-"mX" = (
-/obj/item/stack/pipe_cleaner_coil/cut/yellow,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/engineering/main)
 "na" = (
 /obj/effect/landmark/start/scientist,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -1484,16 +1495,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "nI" = (
-/obj/machinery/autolathe,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
 	},
-/obj/effect/turf_decal/siding/thinplating_new/light{
-	dir = 5
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark/textured,
-/area/station/science/research)
+/obj/effect/turf_decal/siding/thinplating_new,
+/turf/open/floor/circuit/off,
+/area/station/science/robotics/lab)
 "nK" = (
 /obj/item/bodypart/chest/robot,
 /obj/item/bodypart/head/robot,
@@ -1562,15 +1569,14 @@
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "og" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 2
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/science/robotics/lab)
 "ok" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1686,18 +1692,10 @@
 	},
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/station/command/heads_quarters/qm)
-"oT" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/purple/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/science/robotics/lab)
 "oW" = (
-/obj/machinery/door/airlock/command,
-/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/command{
+	name = "Quartermaster's Office"
+	},
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
 	},
@@ -1737,7 +1735,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "pC" = (
@@ -1748,8 +1748,8 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "pE" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
@@ -1819,6 +1819,13 @@
 "qq" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/station/engineering/atmos)
+"qv" = (
+/obj/structure/frame/computer{
+	anchored = 1;
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/station/cargo/warehouse)
 "qy" = (
 /obj/structure/sink/directional/south,
 /obj/structure/mirror{
@@ -1957,17 +1964,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
-"rJ" = (
-/obj/structure/frame/machine,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/thinplating_new/light{
-	dir = 6
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark/textured,
-/area/station/science/research)
 "rM" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/station/maintenance/port)
@@ -2009,14 +2005,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/hallway/primary/aft)
-"sr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/dark,
-/area/station/hallway/primary/port)
 "sw" = (
 /obj/structure/cable,
 /obj/machinery/power/port_gen/pacman/pre_loaded,
@@ -2038,18 +2026,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/station/maintenance/starboard)
-"sK" = (
-/obj/effect/turf_decal/trimline/brown/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
 "sM" = (
 /obj/machinery/light,
 /obj/machinery/status_display/shuttle{
@@ -2076,11 +2052,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "sZ" = (
-/obj/effect/turf_decal/stripes{
-	dir = 8
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/iron/smooth,
-/area/station/cargo/warehouse)
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/science/robotics/lab)
 "ta" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2157,10 +2136,10 @@
 /area/station/medical/medbay/central)
 "tV" = (
 /obj/effect/turf_decal/stripes{
-	dir = 1
+	dir = 8
 	},
-/turf/open/floor/plating/airless,
-/area/station/cargo/miningoffice)
+/turf/open/floor/iron/smooth,
+/area/station/cargo/warehouse)
 "tW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
 /obj/effect/turf_decal/stripes{
@@ -2200,7 +2179,9 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "up" = (
-/turf/open/floor/catwalk_floor/iron,
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "ut" = (
 /obj/structure/cable,
@@ -2251,15 +2232,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"uW" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
 "uY" = (
 /obj/effect/decal/cleanable/oil/streak,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -2351,6 +2323,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"vI" = (
+/obj/structure/chair/stool/bar,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood,
+/area/station/service/cafeteria)
 "vN" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -2366,13 +2343,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
-"vQ" = (
-/obj/structure/sign/nanotrasen{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
 "vS" = (
 /obj/machinery/atmospherics/components/tank/plasma{
 	dir = 8
@@ -2442,42 +2412,29 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "wt" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/effect/turf_decal/siding/thinplating_new/dark{
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes{
-	dir = 4
-	},
-/turf/open/floor/circuit/off,
-/area/station/science/robotics/lab)
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "wv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "ww" = (
-/obj/machinery/suit_storage_unit/engine,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth_large,
-/area/station/engineering/main)
-"wA" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningoffice)
+"wy" = (
+/obj/structure/frame/machine,
+/obj/effect/turf_decal/siding/thinplating_new/light{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
-"wI" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/science/robotics/lab)
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark/textured,
+/area/station/science/research)
 "wP" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -2489,6 +2446,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/hallway/primary/port)
+"wR" = (
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/vending/wardrobe/science_wardrobe,
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/research)
 "wV" = (
 /obj/structure/cable,
 /obj/machinery/light{
@@ -2532,9 +2497,22 @@
 /area/station/maintenance/port)
 "xx" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/catwalk_floor/iron_dark,
+/turf/open/floor/iron/dark,
 /area/station/cargo/warehouse)
+"xz" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/circuit/off,
+/area/station/science/robotics/lab)
+"xL" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/wood,
+/area/station/service/cafeteria)
 "xM" = (
 /obj/structure/cable,
 /obj/machinery/navbeacon{
@@ -2564,6 +2542,18 @@
 "yG" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/station/cargo/warehouse)
+"yO" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "yU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/cable,
@@ -2590,7 +2580,7 @@
 /turf/open/floor/iron/dark/smooth_corner,
 /area/station/command/bridge)
 "zb" = (
-/turf/open/floor/iron/dark/textured,
+/turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "zh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2623,21 +2613,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"zs" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/catwalk_floor/iron,
-/area/station/hallway/primary/aft)
 "zv" = (
-/obj/effect/turf_decal/stripes{
-	dir = 8
-	},
+/obj/machinery/power/smes/engineering,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/smooth,
-/area/station/cargo/warehouse)
+/turf/open/floor/iron/smooth_large,
+/area/station/engineering/main)
 "zz" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 32
@@ -2683,6 +2663,15 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/carpet/blue,
 /area/station/command/bridge)
+"Aa" = (
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/cargo/warehouse)
 "Ac" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2746,15 +2735,8 @@
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "AH" = (
-/obj/structure/bed/pod,
-/obj/item/bedsheet/qm,
-/obj/structure/curtain/cloth,
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/carpet/orange,
-/area/station/command/heads_quarters/qm)
+/turf/open/floor/iron/grimy,
+/area/station/commons/dorms)
 "AK" = (
 /obj/effect/turf_decal/trimline/neutral/warning,
 /obj/machinery/button/door{
@@ -2888,14 +2870,13 @@
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "Cd" = (
-/obj/effect/turf_decal/trimline/brown/line{
+/obj/structure/cable,
+/obj/structure/frame/machine,
+/obj/effect/turf_decal/siding/thinplating_new/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
+/turf/open/floor/iron/dark/textured,
+/area/station/science/research)
 "Cf" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -2962,11 +2943,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/hallway/primary/central)
-"CB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/catwalk_floor/iron_white,
-/area/station/science/robotics/lab)
 "CI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
@@ -2992,8 +2968,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "CR" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/station/command/heads_quarters/qm)
+/obj/machinery/atmospherics/components/tank/plasma{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "CW" = (
 /obj/item/trash/cheesie,
 /obj/effect/turf_decal/tile/red/opposingcorners,
@@ -3028,10 +3007,11 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/station/cargo/miningoffice)
 "Ds" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/obj/machinery/atmospherics/components/tank/air{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "Dw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -3082,14 +3062,17 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port)
-"DL" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
+"DM" = (
+/obj/machinery/autolathe,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
-/obj/effect/turf_decal/siding/thinplating_new,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/circuit/off,
-/area/station/science/robotics/lab)
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 5
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark/textured,
+/area/station/science/research)
 "DP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/light/small,
@@ -3098,37 +3081,10 @@
 "DQ" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/station/service/cafeteria)
-"DR" = (
-/obj/structure/frame/machine,
-/obj/effect/turf_decal/siding/thinplating_new/light{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark/textured,
-/area/station/science/research)
-"DW" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/turf/open/floor/catwalk_floor/iron,
-/area/station/hallway/primary/aft)
 "DX" = (
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/station/medical/medbay/lobby)
-"Ea" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/purple/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/science/robotics/lab)
 "Ed" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
@@ -3243,8 +3199,16 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "Fb" = (
-/turf/open/floor/iron/grimy,
-/area/station/commons/dorms)
+/obj/effect/turf_decal/siding/yellow{
+	dir = 1
+	},
+/obj/structure/chair/office/light,
+/obj/effect/landmark/start/quartermaster,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/qm)
 "Fn" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -3317,7 +3281,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "FG" = (
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
 "FL" = (
 /obj/structure/sign/warning/no_smoking/directional/west,
@@ -3410,17 +3374,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "Gy" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/thinplating_new{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating_new/light{
-	dir = 1
-	},
-/turf/open/floor/circuit/off,
-/area/station/science/robotics/lab)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningoffice)
 "GD" = (
 /turf/closed/wall/mineral/titanium,
 /area/station/medical/medbay/lobby)
@@ -3494,10 +3450,6 @@
 	dir = 1
 	},
 /area/station/command/bridge)
-"HP" = (
-/obj/structure/cable/layer3,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/engineering/main)
 "HS" = (
 /turf/closed/wall/mineral/titanium,
 /area/station/service/cafeteria)
@@ -3527,6 +3479,12 @@
 	},
 /turf/open/floor/wood,
 /area/station/medical/medbay/lobby)
+"Iq" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "Ir" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/public/glass{
@@ -3569,6 +3527,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/starboard)
+"IP" = (
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/structure/rack,
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "IS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -3629,18 +3599,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"Jx" = (
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/structure/rack,
-/obj/effect/turf_decal/stripes{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/lab)
 "JB" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
@@ -3676,6 +3634,14 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
+"JG" = (
+/obj/structure/aquarium/prefilled,
+/obj/item/fish_feed{
+	pixel_y = -9;
+	pixel_x = 8
+	},
+/turf/open/floor/wood,
+/area/station/medical/medbay/lobby)
 "JO" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -3798,9 +3764,10 @@
 /turf/open/floor/iron/grimy,
 /area/station/commons/dorms)
 "Ky" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/wood,
-/area/station/service/cafeteria)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor/iron_white,
+/area/station/science/robotics/lab)
 "KE" = (
 /obj/structure/table,
 /obj/item/clipboard,
@@ -3837,19 +3804,20 @@
 "Lk" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/station/cargo/office)
-"Ln" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+"Ll" = (
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/science/robotics/lab)
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "Lq" = (
 /obj/machinery/firealarm/directional/east,
 /obj/structure/ore_box,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningoffice)
+"Lr" = (
+/obj/effect/turf_decal/bot_white/right,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "Lt" = (
@@ -3870,6 +3838,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
+"Ly" = (
+/obj/structure/table_frame,
+/obj/effect/turf_decal/tile/red/diagonal_centre,
+/turf/open/floor/iron/white/diagonal,
+/area/station/science/robotics/lab)
 "LB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/item/wrench,
@@ -3976,6 +3949,17 @@
 /obj/effect/turf_decal/siding/thinplating_new/light,
 /turf/open/floor/iron,
 /area/station/medical/medbay/central)
+"ML" = (
+/obj/structure/frame/machine,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 6
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark/textured,
+/area/station/science/research)
 "MM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -3983,21 +3967,19 @@
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "MO" = (
-/obj/effect/turf_decal/siding/yellow{
-	dir = 1
-	},
-/obj/structure/chair/office/light,
-/obj/effect/landmark/start/quartermaster,
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/qm)
-"MQ" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood,
-/area/station/service/cafeteria)
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
+"MQ" = (
+/obj/structure/cable/layer3,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/engineering/main)
 "MY" = (
 /obj/machinery/cryopod,
 /obj/machinery/light/small,
@@ -4019,14 +4001,6 @@
 	dir = 1
 	},
 /area/station/command/bridge)
-"Nh" = (
-/obj/structure/cable,
-/obj/structure/frame/machine,
-/obj/effect/turf_decal/siding/thinplating_new/light{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/science/research)
 "Nr" = (
 /obj/structure/table,
 /obj/item/reagent_containers/cup/bucket,
@@ -4050,11 +4024,6 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/engineering/main)
-"NG" = (
-/obj/structure/table_frame,
-/obj/effect/turf_decal/tile/red/diagonal_centre,
-/turf/open/floor/iron/white/diagonal,
-/area/station/science/robotics/lab)
 "NP" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "ospreycargo"
@@ -4176,6 +4145,11 @@
 /obj/item/clothing/gloves/color/latex,
 /turf/open/floor/iron,
 /area/station/medical/medbay/central)
+"OP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/cargo/warehouse)
 "OR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4206,14 +4180,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/cargo/office)
-"Pf" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/effect/turf_decal/siding/thinplating_new/dark{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/circuit/off,
-/area/station/science/robotics/lab)
 "Ph" = (
 /obj/structure/table/wood,
 /obj/item/folder,
@@ -4246,6 +4212,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
+"PF" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	id = "ospreywindows";
+	name = "Blast Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/command/heads_quarters/qm)
 "PJ" = (
 /obj/structure/window/reinforced/plasma/spawner/west,
 /obj/structure/window/reinforced/plasma/spawner/north,
@@ -4267,6 +4241,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"PS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/hallway/primary/starboard)
 "PU" = (
 /turf/open/floor/iron/white,
 /area/station/science/research)
@@ -4294,6 +4275,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/service/janitor)
+"Qn" = (
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/smooth,
+/area/station/cargo/warehouse)
 "Qq" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -4306,6 +4296,9 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron/dark,
 /area/station/cargo/warehouse)
+"Qr" = (
+/turf/closed/wall/mineral/titanium,
+/area/station/command/heads_quarters/qm)
 "Qu" = (
 /obj/machinery/computer/atmos_alert{
 	dir = 8
@@ -4364,6 +4357,15 @@
 /obj/structure/fireaxecabinet/directional/west,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/atmos)
+"QS" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/science/robotics/lab)
 "QT" = (
 /obj/machinery/light{
 	dir = 1
@@ -4403,11 +4405,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "Rm" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/cargo/warehouse)
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/station/cargo/miningoffice)
 "Rv" = (
 /obj/machinery/light{
 	dir = 8
@@ -4437,12 +4439,6 @@
 "RG" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/station/science/research)
-"RO" = (
-/obj/machinery/atmospherics/components/tank/air{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "RZ" = (
 /obj/structure/dresser,
 /obj/machinery/firealarm/directional/south,
@@ -4459,6 +4455,18 @@
 /obj/effect/spawner/random/maintenance/three,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/smooth,
+/area/station/cargo/warehouse)
+"Sh" = (
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/cargo/warehouse)
 "Sl" = (
 /obj/structure/closet/crate/coffin,
@@ -4489,19 +4497,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/service/janitor)
-"SK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
 "SN" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/airalarm/directional/east,
@@ -4519,9 +4514,8 @@
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "SP" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/turf/open/floor/catwalk_floor/iron,
+/area/station/hallway/primary/aft)
 "SQ" = (
 /obj/structure/cable,
 /obj/structure/window/reinforced/plasma/spawner,
@@ -4534,6 +4528,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"ST" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/science/robotics/lab)
 "SU" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
@@ -4549,13 +4547,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/service/janitor)
-"Tc" = (
-/obj/machinery/vending/wardrobe/cargo_wardrobe,
-/obj/effect/turf_decal/siding/thinplating_new{
-	dir = 8
-	},
-/turf/open/floor/iron/smooth,
-/area/station/cargo/office)
 "Td" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -4566,6 +4557,19 @@
 	},
 /turf/open/floor/plating,
 /area/station/service/janitor)
+"Tg" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/griddle,
+/obj/structure/window/spawner/north,
+/obj/structure/window/spawner/east,
+/turf/open/floor/iron/showroomfloor,
+/area/station/service/cafeteria)
 "Ti" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4596,10 +4600,6 @@
 /obj/structure/window/reinforced/plasma/spawner/north,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
-"Tv" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/cargo/miningoffice)
 "Tw" = (
 /obj/machinery/door/airlock/public/glass,
 /turf/open/floor/iron,
@@ -4693,6 +4693,13 @@
 "Ur" = (
 /turf/closed/wall/mineral/titanium,
 /area/station/medical/medbay/central)
+"Uu" = (
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/engineering/main)
 "Uv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4712,17 +4719,10 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/cargo/warehouse)
-"UH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/service/cafeteria)
+"UK" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/station/engineering/main)
 "US" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -4765,15 +4765,14 @@
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "Vr" = (
-/obj/effect/turf_decal/stripes{
-	dir = 1
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 2
 	},
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/closet/emcloset/anchored,
-/turf/open/floor/plating/airless,
-/area/station/cargo/miningoffice)
+/turf/open/floor/catwalk_floor/iron,
+/area/station/hallway/primary/aft)
 "Vu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/machinery/light/small{
@@ -4789,21 +4788,12 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
-"VD" = (
-/obj/structure/aquarium/prefilled,
-/obj/item/fish_feed{
-	pixel_y = -9;
-	pixel_x = 8
-	},
-/turf/open/floor/wood,
-/area/station/medical/medbay/lobby)
 "VF" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "VM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
@@ -4847,11 +4837,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port)
-"WA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
 "WJ" = (
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
@@ -4910,13 +4895,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port)
-"Xl" = (
-/obj/effect/turf_decal/stripes{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/engineering/main)
 "Xm" = (
 /obj/machinery/medical_kiosk,
 /obj/machinery/light{
@@ -4935,12 +4913,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
-"Xt" = (
-/obj/machinery/atmospherics/components/tank/plasma{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "XB" = (
 /obj/structure/railing{
 	dir = 8
@@ -4993,11 +4965,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "XR" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/station/command/heads_quarters/qm)
 "XS" = (
 /obj/structure/closet/secure_closet/captains{
 	icon_state = "cap";
@@ -5019,8 +4988,18 @@
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "Ym" = (
-/turf/closed/wall/mineral/titanium,
-/area/station/command/heads_quarters/qm)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "Yn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -5050,6 +5029,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/main)
+"YH" = (
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/closet/emcloset/anchored,
+/turf/open/floor/plating/airless,
+/area/station/cargo/miningoffice)
 "YK" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -5106,7 +5095,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "ZN" = (
@@ -5129,6 +5120,16 @@
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
+"ZY" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 
 (1,1,1) = {"
 XU
@@ -5284,7 +5285,7 @@ cq
 Jk
 rj
 VF
-aJ
+Tg
 cu
 rv
 dy
@@ -5340,9 +5341,9 @@ XU
 XU
 cq
 Ep
-Ky
-MQ
-UH
+xL
+vI
+aJ
 cu
 cu
 Ms
@@ -5400,7 +5401,7 @@ cq
 jV
 rj
 fR
-UH
+aJ
 cu
 UT
 jy
@@ -5471,7 +5472,7 @@ pT
 pT
 sl
 mR
-sr
+fI
 rM
 zz
 il
@@ -5523,11 +5524,11 @@ DQ
 iO
 QA
 uP
-fS
+fx
 gm
-fS
+fx
 Rd
-sr
+fI
 kW
 yU
 rM
@@ -5582,7 +5583,7 @@ ox
 Zt
 nl
 bs
-jU
+Ll
 PY
 UU
 QV
@@ -5604,7 +5605,7 @@ XU
 hw
 zI
 jN
-NG
+Ly
 mV
 oO
 pi
@@ -5662,8 +5663,8 @@ hw
 Dp
 zI
 gM
-eG
-Gy
+jn
+it
 Gn
 CW
 lT
@@ -5686,7 +5687,7 @@ XU
 XU
 XU
 sn
-Ds
+up
 Hv
 Ox
 WJ
@@ -5723,7 +5724,7 @@ WR
 mk
 nM
 vm
-jn
+nI
 nK
 zI
 RG
@@ -5745,12 +5746,12 @@ XU
 Ur
 pO
 ow
-kw
+gI
 Ox
-up
+SP
 Ov
 HE
-zs
+km
 Ev
 hk
 XH
@@ -5778,13 +5779,13 @@ Cm
 aw
 KO
 qO
-Pf
+eH
 JO
 IB
-DL
+xz
 rX
 RG
-cm
+wR
 RG
 LP
 RG
@@ -5802,8 +5803,8 @@ TV
 Do
 Do
 pO
-ZK
-kw
+wt
+gI
 qn
 qn
 qn
@@ -5829,14 +5830,14 @@ XU
 (13,1,1) = {"
 XU
 XU
-Vr
+YH
 ap
 mQ
 aw
 fE
 KO
-Jx
-wt
+IP
+cm
 rF
 Av
 qc
@@ -5868,10 +5869,10 @@ hC
 zW
 Lh
 sB
-uW
+ZK
 BC
 xh
-SP
+UK
 KV
 qf
 qf
@@ -5887,27 +5888,27 @@ XU
 (14,1,1) = {"
 XU
 XU
-tV
+Rm
 jh
 aw
-dr
+Gy
 zJ
 ui
-lY
+ST
 qT
 Am
 qT
-CB
-wI
+Ky
+lY
 gc
 Rg
 EO
 Kd
-Nh
+Cd
 az
 Ax
 JB
-XR
+pE
 Ac
 tf
 Do
@@ -5918,8 +5919,8 @@ Dc
 tO
 ab
 pO
-it
-kw
+fO
+gI
 td
 Ng
 Is
@@ -5927,9 +5928,9 @@ AW
 VO
 sB
 tj
-SK
+mO
 xh
-dW
+jU
 aC
 ml
 ep
@@ -5945,18 +5946,18 @@ XU
 (15,1,1) = {"
 XU
 XU
-tV
+Rm
 jh
 aw
-gC
+Lr
 aw
 JF
-Ea
-oT
+kE
+QS
 ea
 Cb
-Ln
-kE
+og
+sZ
 Gv
 PU
 na
@@ -5987,11 +5988,11 @@ vp
 ZN
 vo
 Hp
-FG
-HP
-Xl
+zb
+MQ
+Uu
 qa
-mX
+mL
 qa
 qf
 XU
@@ -6003,7 +6004,7 @@ XU
 (16,1,1) = {"
 XU
 XU
-tV
+Rm
 jh
 vN
 vN
@@ -6018,9 +6019,9 @@ yG
 RG
 RG
 RG
-nI
-DR
-rJ
+DM
+wy
+ML
 RG
 RG
 Hq
@@ -6045,7 +6046,7 @@ Mp
 vT
 wY
 Hp
-FG
+zb
 aC
 aB
 qa
@@ -6061,17 +6062,17 @@ XU
 (17,1,1) = {"
 XU
 XU
-tV
+Rm
 jh
 aw
 TB
-Tv
+VM
 Jn
 Rv
 vW
-Cd
-Cd
-sK
+Aa
+Aa
+Sh
 Rv
 vj
 ut
@@ -6103,8 +6104,8 @@ vp
 QB
 vo
 Hp
-FG
-HP
+zb
+MQ
 tc
 qa
 gu
@@ -6119,18 +6120,18 @@ XU
 (18,1,1) = {"
 XU
 XU
-tV
+Rm
 jh
 aw
 Xb
-VM
+ww
 Qq
-WA
+OP
 UE
 qC
+mr
+fS
 xx
-Rm
-ad
 mv
 OV
 uY
@@ -6139,7 +6140,7 @@ gD
 ES
 fD
 Cn
-pE
+Iq
 kU
 yB
 Ir
@@ -6150,7 +6151,7 @@ xM
 Im
 yj
 jS
-eA
+yO
 gX
 td
 HF
@@ -6158,10 +6159,10 @@ Is
 tr
 ae
 sB
-vQ
-ci
+cP
+Ym
 xh
-zb
+FG
 aC
 AM
 sw
@@ -6177,18 +6178,18 @@ XU
 (19,1,1) = {"
 XU
 XU
-Vr
+YH
 ap
 Mj
 aw
 aw
 iq
-sZ
-sZ
-sZ
-sZ
-zv
-sZ
+tV
+tV
+tV
+tV
+Qn
+tV
 ip
 wj
 mJ
@@ -6204,7 +6205,7 @@ sf
 BG
 wi
 Xm
-VD
+JG
 TM
 jT
 HD
@@ -6217,7 +6218,7 @@ dI
 XS
 sB
 JV
-ci
+Ym
 xh
 ER
 Hh
@@ -6241,14 +6242,14 @@ Bq
 Os
 aw
 JU
-hN
+ln
 Sc
 nO
 oP
 qe
 RC
 Lk
-Tc
+le
 Lk
 BR
 Lk
@@ -6280,7 +6281,7 @@ xh
 js
 OU
 fb
-eq
+zv
 qf
 lU
 XU
@@ -6298,11 +6299,11 @@ Dp
 hw
 dj
 Lq
-CR
+XR
 oR
-CR
-CR
-CR
+XR
+XR
+XR
 qe
 sM
 yG
@@ -6325,14 +6326,14 @@ XU
 GD
 pO
 cj
-wA
+ps
 eY
-DW
+Vr
 mo
 rW
-DW
-og
-ps
+Vr
+ZY
+MO
 FC
 va
 gy
@@ -6356,7 +6357,7 @@ XU
 hw
 hw
 Dp
-CR
+XR
 zF
 Xp
 oK
@@ -6396,7 +6397,7 @@ aG
 HB
 jg
 Aw
-ww
+eq
 qf
 lU
 XU
@@ -6414,12 +6415,12 @@ XU
 XU
 XU
 hw
-CR
-AH
-MO
+XR
+dn
+Fb
 KE
-CR
-ln
+XR
+qv
 ug
 yG
 aX
@@ -6472,11 +6473,11 @@ XU
 XU
 XU
 XU
-Ym
-CR
-fx
-CR
-CR
+Qr
+XR
+PF
+XR
+XR
 ki
 yG
 ja
@@ -6501,7 +6502,7 @@ XU
 XU
 mE
 RZ
-Fb
+AH
 ta
 SO
 Yd
@@ -6510,7 +6511,7 @@ kf
 cg
 lq
 nn
-eo
+gY
 Ml
 ao
 AZ
@@ -6631,7 +6632,7 @@ qq
 qq
 Hd
 mI
-fI
+PS
 PK
 cc
 oy
@@ -6733,7 +6734,7 @@ XU
 te
 xi
 hM
-Fb
+AH
 mE
 TU
 Zs
@@ -6854,12 +6855,12 @@ mE
 qy
 Vl
 If
-Xt
+CR
 vS
 PW
 Qu
 iS
-RO
+Ds
 PK
 kJ
 sH

--- a/_maps/voidcrew/ship_osprey.dmm
+++ b/_maps/voidcrew/ship_osprey.dmm
@@ -3,7 +3,10 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/shuttle/voidcrew/osprey/medbay)
+"ac" = (
+/turf/open/floor/iron,
+/area/shuttle/voidcrew/osprey/hallway/starboard)
 "ae" = (
 /obj/machinery/light/small,
 /obj/structure/curtain/cloth/fancy,
@@ -14,7 +17,7 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/royalblue,
-/area/station/command/bridge)
+/area/shuttle/voidcrew/osprey/bridge)
 "af" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -24,17 +27,7 @@
 	},
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/iron,
-/area/station/medical/medbay/lobby)
-"ao" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/station/hallway/primary/starboard)
-"ap" = (
-/obj/structure/sign/warning/vacuum/external,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/station/cargo/miningoffice)
-"aw" = (
-/turf/open/floor/iron/dark,
-/area/station/cargo/miningoffice)
+/area/shuttle/voidcrew/osprey/medbay/lobby)
 "az" = (
 /obj/machinery/computer/rdconsole{
 	dir = 4
@@ -46,7 +39,7 @@
 	dir = 10
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/science/research)
+/area/shuttle/voidcrew/osprey/research)
 "aB" = (
 /obj/effect/turf_decal/stripes{
 	dir = 1
@@ -54,11 +47,11 @@
 /obj/structure/cable,
 /obj/item/wirecutters,
 /turf/open/floor/plating,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "aC" = (
 /obj/structure/cable/multilayer/connected,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "aE" = (
 /obj/item/radio,
 /obj/item/radio,
@@ -81,19 +74,11 @@
 /obj/item/radio,
 /obj/item/radio,
 /turf/open/floor/iron/grimy,
-/area/station/commons/dorms)
-"aF" = (
-/obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor/shutters{
-	id = "ospreywindows";
-	name = "Blast Shutters"
-	},
-/turf/open/floor/plating,
-/area/station/medical/medbay/lobby)
+/area/shuttle/voidcrew/osprey/service/dormitories)
 "aG" = (
 /obj/structure/sign/departments/engineering,
 /turf/closed/wall/mineral/titanium/interior,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "aJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -104,7 +89,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/service/cafeteria)
+/area/shuttle/voidcrew/osprey/service/cafeteria)
 "aK" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -113,10 +98,10 @@
 	dir = 10
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
-"aX" = (
+/area/shuttle/voidcrew/osprey/hallway/aft)
+"aW" = (
 /turf/closed/wall/mineral/titanium,
-/area/station/cargo/office)
+/area/shuttle/voidcrew/osprey/cargo)
 "bf" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -127,14 +112,14 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/port)
+/area/shuttle/voidcrew/osprey/hallway/port)
 "bn" = (
 /obj/structure/table/optable,
 /obj/machinery/defibrillator_mount/loaded{
 	pixel_y = 24
 	},
 /turf/open/floor/iron,
-/area/station/medical/medbay/central)
+/area/shuttle/voidcrew/osprey/medbay)
 "bs" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
@@ -142,7 +127,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/area/shuttle/voidcrew/osprey/hallway/port)
 "bz" = (
 /obj/machinery/door/poddoor{
 	id = "osprey_disposals";
@@ -150,7 +135,7 @@
 	},
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
-/area/station/service/janitor)
+/area/shuttle/voidcrew/osprey/service/janitor)
 "bD" = (
 /obj/machinery/power/smes/engineering{
 	dir = 1
@@ -167,11 +152,11 @@
 	name = "Thruster Blast Door"
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/shuttle/voidcrew/osprey/maintenance/starboard)
 "bI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
-/area/station/service/cafeteria)
+/area/shuttle/voidcrew/osprey/service/cafeteria)
 "bL" = (
 /obj/machinery/button/door{
 	dir = 4;
@@ -186,17 +171,14 @@
 	pixel_y = -6
 	},
 /turf/open/floor/iron/dark,
-/area/station/cargo/miningoffice)
+/area/shuttle/voidcrew/osprey/cargo/mining_dock)
 "bN" = (
 /obj/machinery/power/terminal{
 	dir = 8
 	},
 /obj/structure/cable/multilayer/connected,
 /turf/open/floor/catwalk_floor/iron_smooth,
-/area/station/engineering/main)
-"bP" = (
-/turf/closed/wall/mineral/titanium,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/engineering)
 "bQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -209,15 +191,15 @@
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
-/area/station/engineering/atmos)
+/area/shuttle/voidcrew/osprey/engineering/atmospherics)
 "bT" = (
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/shuttle/voidcrew/osprey/hallway/starboard)
 "cb" = (
 /obj/structure/sign/warning/electric_shock,
 /turf/closed/wall/mineral/titanium,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "cc" = (
 /obj/structure/cable,
 /obj/structure/window/reinforced/spawner/west{
@@ -228,7 +210,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/shuttle/voidcrew/osprey/maintenance/starboard)
 "cg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/cable,
@@ -238,7 +220,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "cj" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -251,7 +233,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "cm" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -260,24 +242,16 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/cargo/office)
-"cq" = (
-/obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor/shutters{
-	id = "ospreywindows";
-	name = "Blast Shutters"
-	},
-/turf/open/floor/plating,
-/area/station/service/cafeteria)
+/area/shuttle/voidcrew/osprey/cargo)
 "cr" = (
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "cu" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron/showroomfloor,
-/area/station/service/cafeteria)
+/area/shuttle/voidcrew/osprey/service/cafeteria)
 "cw" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -286,21 +260,21 @@
 	dir = 8
 	},
 /turf/open/floor/iron/grimy,
-/area/station/commons/dorms)
+/area/shuttle/voidcrew/osprey/service/dormitories)
 "cC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
-/area/station/service/janitor)
+/area/shuttle/voidcrew/osprey/service/janitor)
 "cJ" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/thinplating_new,
 /turf/open/floor/circuit/off,
-/area/station/science/robotics/lab)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "cK" = (
 /obj/structure/closet/secure_closet{
 	icon_state = "med";
@@ -332,7 +306,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/medical/medbay/central)
+/area/shuttle/voidcrew/osprey/medbay)
 "cS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/cable,
@@ -343,7 +317,11 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/area/shuttle/voidcrew/osprey/hallway/port)
+"cW" = (
+/obj/structure/sign/departments/medbay/alt,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/voidcrew/osprey/medbay/lobby)
 "cY" = (
 /obj/structure/cable,
 /obj/structure/window/reinforced/plasma/spawner,
@@ -356,7 +334,15 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/port)
+/area/shuttle/voidcrew/osprey/maintenance/port)
+"dd" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	id = "ospreywindows";
+	name = "Blast Shutters"
+	},
+/turf/open/floor/plating,
+/area/shuttle/voidcrew/osprey/service/dormitories)
 "dj" = (
 /obj/structure/rack,
 /obj/item/pickaxe,
@@ -379,15 +365,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
-/area/station/cargo/miningoffice)
-"dm" = (
-/obj/machinery/door/airlock/maintenance_hatch,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/shuttle/voidcrew/osprey/cargo/mining_dock)
 "dr" = (
 /obj/effect/turf_decal/stripes{
 	dir = 1
@@ -397,7 +375,7 @@
 	},
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/plating/airless,
-/area/station/cargo/miningoffice)
+/area/shuttle/voidcrew/osprey/cargo/mining_dock)
 "dw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -410,30 +388,30 @@
 /obj/structure/window/spawner/north,
 /obj/structure/window/spawner/east,
 /turf/open/floor/iron/showroomfloor,
-/area/station/service/cafeteria)
+/area/shuttle/voidcrew/osprey/service/cafeteria)
 "dy" = (
 /obj/machinery/light,
 /obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/showroomfloor,
-/area/station/service/cafeteria)
+/area/shuttle/voidcrew/osprey/service/cafeteria)
 "dC" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "dI" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /turf/open/floor/carpet/royalblue,
-/area/station/command/bridge)
+/area/shuttle/voidcrew/osprey/bridge)
 "dJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/stairs{
 	dir = 8
 	},
-/area/station/command/bridge)
+/area/shuttle/voidcrew/osprey/bridge)
 "dK" = (
 /obj/structure/railing,
 /obj/effect/landmark/start/captain,
@@ -445,14 +423,22 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/command/bridge)
+/area/shuttle/voidcrew/osprey/bridge)
+"dZ" = (
+/obj/structure/window/reinforced/plasma/spawner/east,
+/obj/structure/window/reinforced/plasma/spawner/north,
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/voidcrew/osprey/maintenance/port)
 "ea" = (
 /obj/structure/sign/poster/official/random/directional/east,
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/science/robotics/lab)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "eb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/structure/cable,
@@ -460,57 +446,52 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/port)
+/area/shuttle/voidcrew/osprey/maintenance/port)
 "ec" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/mop_bucket/janitorialcart,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
-/area/station/service/janitor)
-"ef" = (
-/obj/structure/window/reinforced/plasma/spawner/east,
-/obj/structure/window/reinforced/plasma/spawner/north,
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/port)
+/area/shuttle/voidcrew/osprey/service/janitor)
 "ej" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/reagent_dispensers/fueltank,
 /obj/structure/sign/warning/no_smoking/directional/south,
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
-/area/station/cargo/miningoffice)
+/area/shuttle/voidcrew/osprey/cargo/mining_dock)
 "el" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/service/janitor)
+/area/shuttle/voidcrew/osprey/service/janitor)
 "ep" = (
 /obj/structure/cable,
 /obj/machinery/power/port_gen/pacman/super,
 /turf/open/floor/plating,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "eq" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "eB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/station/medical/medbay/lobby)
+/area/shuttle/voidcrew/osprey/medbay/lobby)
 "eM" = (
 /obj/machinery/computer/atmos_alert{
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/smooth_large,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
+"eO" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/voidcrew/osprey/cargo/warehouse)
 "eP" = (
 /obj/machinery/atmospherics/components/tank/plasma{
 	dir = 8
@@ -520,7 +501,10 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/shuttle/voidcrew/osprey/maintenance/starboard)
+"eQ" = (
+/turf/open/floor/iron/dark,
+/area/shuttle/voidcrew/osprey/engineering)
 "eY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -529,19 +513,19 @@
 	dir = 2
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "fb" = (
 /obj/structure/cable,
 /obj/machinery/power/smes/engineering,
 /turf/open/floor/iron/smooth_large,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "ff" = (
 /obj/machinery/atmospherics/components/tank/plasma{
 	dir = 4
 	},
 /obj/structure/sign/warning/no_smoking/directional/west,
 /turf/open/floor/plating,
-/area/station/maintenance/port)
+/area/shuttle/voidcrew/osprey/maintenance/port)
 "fi" = (
 /obj/structure/table,
 /obj/item/storage/belt/janitor,
@@ -550,19 +534,19 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
-/area/station/service/janitor)
+/area/shuttle/voidcrew/osprey/service/janitor)
 "fq" = (
 /obj/effect/landmark/start/shaft_miner,
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
-/area/station/cargo/office)
+/area/shuttle/voidcrew/osprey/cargo)
 "fs" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "fx" = (
 /obj/structure/frame/machine,
 /obj/effect/turf_decal/tile/purple{
@@ -573,30 +557,30 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark/textured,
-/area/station/science/research)
+/area/shuttle/voidcrew/osprey/research)
 "fD" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/iron,
-/area/station/cargo/office)
+/area/shuttle/voidcrew/osprey/cargo)
 "fE" = (
 /obj/structure/tank_dispenser/oxygen,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
-/area/station/cargo/miningoffice)
+/area/shuttle/voidcrew/osprey/cargo/mining_dock)
 "fI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
+/area/shuttle/voidcrew/osprey/cargo/warehouse)
 "fL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
-/area/station/science/research)
+/area/shuttle/voidcrew/osprey/research)
 "fR" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=bridge";
@@ -605,7 +589,7 @@
 /obj/structure/chair/stool/bar,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
-/area/station/service/cafeteria)
+/area/shuttle/voidcrew/osprey/service/cafeteria)
 "fS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/cable,
@@ -615,13 +599,13 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/area/shuttle/voidcrew/osprey/hallway/port)
 "fU" = (
 /obj/machinery/power/shuttle_engine/ship/fueled/plasma{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/shuttle/voidcrew/osprey/maintenance/port)
 "fY" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -634,7 +618,7 @@
 	dir = 1
 	},
 /turf/open/floor/carpet,
-/area/station/commons/dorms)
+/area/shuttle/voidcrew/osprey/service/dormitories)
 "fZ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -646,15 +630,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
-"gb" = (
-/obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor/shutters{
-	id = "ospreywindows";
-	name = "Blast Shutters"
-	},
-/turf/open/floor/plating,
-/area/station/science/robotics/lab)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "gc" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Laboratory"
@@ -666,7 +642,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/station/science/research)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "gh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/cable,
@@ -675,7 +651,7 @@
 /obj/machinery/firealarm/directional/south,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
-/area/station/hallway/primary/starboard)
+/area/shuttle/voidcrew/osprey/hallway/starboard)
 "gm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/cable,
@@ -686,25 +662,33 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/area/shuttle/voidcrew/osprey/hallway/port)
+"gq" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	id = "ospreywindows";
+	name = "Blast Shutters"
+	},
+/turf/open/floor/plating,
+/area/shuttle/voidcrew/osprey/cargo)
 "gr" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = -32
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/plating,
-/area/station/maintenance/port)
+/area/shuttle/voidcrew/osprey/maintenance/port)
 "gu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "gy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "gB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -713,7 +697,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/shuttle/voidcrew/osprey/hallway/central)
 "gD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -722,11 +706,11 @@
 	dir = 2
 	},
 /turf/open/floor/catwalk_floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "gF" = (
 /obj/structure/sign/warning/vacuum/external,
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/station/maintenance/starboard)
+/area/shuttle/voidcrew/osprey/maintenance/starboard)
 "gM" = (
 /obj/item/wallframe/camera,
 /obj/item/wallframe/camera,
@@ -747,7 +731,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red/diagonal_centre,
 /turf/open/floor/iron/white/diagonal,
-/area/station/science/robotics/lab)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "gU" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -756,14 +740,22 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plating,
-/area/station/engineering/atmos)
+/area/shuttle/voidcrew/osprey/engineering/atmospherics)
 "gX" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
+"gZ" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	id = "ospreywindows";
+	name = "Blast Shutters"
+	},
+/turf/open/floor/plating,
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "hk" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -772,17 +764,14 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "hq" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "ospreysci"
 	},
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
-/area/station/science/research)
-"hw" = (
-/turf/closed/wall/mineral/titanium,
-/area/station/cargo/miningoffice)
+/area/shuttle/voidcrew/osprey/research)
 "hz" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
@@ -799,10 +788,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/cargo/miningoffice)
-"hB" = (
-/turf/closed/wall/mineral/titanium,
-/area/station/science/robotics/lab)
+/area/shuttle/voidcrew/osprey/cargo/mining_dock)
 "hC" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -841,32 +827,26 @@
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 8
 	},
-/area/station/command/bridge)
+/area/shuttle/voidcrew/osprey/bridge)
 "hM" = (
 /obj/effect/landmark/start/assistant,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
-/area/station/commons/dorms)
-"il" = (
-/obj/machinery/power/terminal,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/port)
-"ip" = (
-/obj/effect/spawner/structure/window/reinforced/shuttle,
-/turf/open/floor/plating,
-/area/station/cargo/office)
+/area/shuttle/voidcrew/osprey/service/dormitories)
+"id" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/voidcrew/osprey/maintenance/port)
 "iq" = (
 /obj/machinery/mineral/ore_redemption,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/shuttle/voidcrew/osprey/cargo/warehouse)
 "it" = (
 /obj/item/stack/pipe_cleaner_coil/cut/yellow,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "iw" = (
 /obj/item/paper_bin{
 	pixel_x = 6
@@ -890,13 +870,13 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/shuttle/voidcrew/osprey/medbay)
 "iy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/junction/flip,
 /turf/open/floor/wood,
-/area/station/medical/medbay/lobby)
+/area/shuttle/voidcrew/osprey/medbay/lobby)
 "iC" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
@@ -929,41 +909,34 @@
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 4
 	},
-/area/station/command/bridge)
-"iF" = (
-/turf/closed/wall/mineral/titanium,
-/area/station/hallway/primary/port)
+/area/shuttle/voidcrew/osprey/bridge)
 "iH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /obj/structure/sign/warning/engine_safety/directional/north,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "iO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/area/shuttle/voidcrew/osprey/hallway/port)
 "iS" = (
 /obj/machinery/atmospherics/components/tank/air{
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/station/engineering/atmos)
+/area/shuttle/voidcrew/osprey/engineering/atmospherics)
 "ja" = (
 /turf/closed/wall/mineral/titanium,
-/area/station/cargo/warehouse)
-"jf" = (
-/obj/structure/sign/warning/vacuum/external,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/station/maintenance/port)
+/area/shuttle/voidcrew/osprey/engineering)
 "jg" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/item/clothing/gloves/color/yellow,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "jh" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/poddoor{
@@ -972,7 +945,7 @@
 	},
 /obj/effect/turf_decal/stripes,
 /turf/open/floor/plating,
-/area/station/cargo/miningoffice)
+/area/shuttle/voidcrew/osprey/cargo/mining_dock)
 "jn" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
@@ -984,7 +957,7 @@
 	dir = 1
 	},
 /turf/open/floor/circuit/off,
-/area/station/science/robotics/lab)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "js" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -992,22 +965,31 @@
 /obj/machinery/firealarm/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
+"jw" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "jy" = (
 /obj/machinery/vending/dinnerware,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron/showroomfloor,
-/area/station/service/cafeteria)
+/area/shuttle/voidcrew/osprey/service/cafeteria)
 "jA" = (
 /obj/machinery/firealarm/directional/north,
 /obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/wood,
-/area/station/service/cafeteria)
+/area/shuttle/voidcrew/osprey/service/cafeteria)
 "jC" = (
 /obj/structure/closet/wardrobe/grey,
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/carpet,
-/area/station/commons/dorms)
+/area/shuttle/voidcrew/osprey/service/dormitories)
 "jE" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4
@@ -1017,7 +999,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/shuttle/voidcrew/osprey/maintenance/starboard)
 "jN" = (
 /obj/structure/frame/computer{
 	anchored = 1;
@@ -1026,13 +1008,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/dark/diagonal_centre,
 /turf/open/floor/iron/white/diagonal,
-/area/station/science/robotics/lab)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "jP" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/engineering/atmos)
+/area/shuttle/voidcrew/osprey/engineering/atmospherics)
 "jS" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/public/glass{
@@ -1042,7 +1024,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/medbay/lobby)
 "jT" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -1052,35 +1034,33 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/station/medical/medbay/lobby)
+/area/shuttle/voidcrew/osprey/medbay/lobby)
 "jU" = (
 /turf/open/floor/iron/dark/textured,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "jV" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/station/service/cafeteria)
+/area/shuttle/voidcrew/osprey/service/cafeteria)
 "ka" = (
 /obj/machinery/pipedispenser,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/effect/turf_decal/stripes,
 /turf/open/floor/plating,
-/area/station/engineering/atmos)
+/area/shuttle/voidcrew/osprey/engineering/atmospherics)
+"kd" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/voidcrew/osprey/cargo/warehouse)
+"ke" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/voidcrew/osprey/bridge)
 "kf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
-"ki" = (
-/obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor/shutters{
-	id = "ospreywindows";
-	name = "Blast Shutters"
-	},
-/turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/shuttle/voidcrew/osprey/hallway/starboard)
 "kj" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/status_display/shuttle{
@@ -1088,28 +1068,18 @@
 	},
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/open/floor/iron/dark,
-/area/station/cargo/miningoffice)
+/area/shuttle/voidcrew/osprey/cargo/mining_dock)
 "kl" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
-/area/station/commons/dorms)
-"kp" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard)
-"kq" = (
-/obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor/shutters{
-	id = "ospreywindows";
-	name = "Blast Shutters"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/service/dormitories)
+"kw" = (
+/obj/structure/sign/warning/vacuum/external,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/voidcrew/osprey/cargo/mining_dock)
 "kE" = (
 /obj/machinery/light{
 	dir = 4
@@ -1119,15 +1089,19 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/science/robotics/lab)
-"kH" = (
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "kJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/shuttle/voidcrew/osprey/hallway/starboard)
+"kN" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	id = "ospreywindows";
+	name = "Blast Shutters"
+	},
+/turf/open/floor/plating,
+/area/shuttle/voidcrew/osprey/research/robotics)
 "kO" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering"
@@ -1140,21 +1114,12 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "kS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_white,
-/area/station/science/robotics/lab)
-"kU" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "kW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/cable,
@@ -1163,25 +1128,25 @@
 /obj/item/stack/tile/iron/dark,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
-/area/station/hallway/primary/port)
+/area/shuttle/voidcrew/osprey/hallway/port)
 "lc" = (
 /obj/item/storage/bag/trash,
 /obj/item/mop,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/station/service/janitor)
+/area/shuttle/voidcrew/osprey/service/janitor)
 "lf" = (
 /obj/machinery/suit_storage_unit/atmos,
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/plating,
-/area/station/engineering/atmos)
+/area/shuttle/voidcrew/osprey/engineering/atmospherics)
 "lg" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/commons/dorms)
+/area/shuttle/voidcrew/osprey/service/dormitories)
 "lh" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/start/assistant,
@@ -1189,7 +1154,7 @@
 	dir = 1
 	},
 /turf/open/floor/carpet,
-/area/station/commons/dorms)
+/area/shuttle/voidcrew/osprey/service/dormitories)
 "li" = (
 /obj/machinery/computer/helm,
 /obj/effect/turf_decal/tile/dark_blue/half{
@@ -1198,17 +1163,17 @@
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 1
 	},
-/area/station/command/bridge)
+/area/shuttle/voidcrew/osprey/bridge)
 "lk" = (
 /obj/machinery/light,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/shuttle/voidcrew/osprey/medbay)
 "ln" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/smooth,
-/area/station/cargo/warehouse)
+/area/shuttle/voidcrew/osprey/cargo/warehouse)
 "lq" = (
 /obj/machinery/light{
 	dir = 8
@@ -1218,7 +1183,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/shuttle/voidcrew/osprey/hallway/starboard)
 "lv" = (
 /obj/effect/turf_decal/trimline/brown/line{
 	dir = 8
@@ -1230,7 +1195,13 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
+/area/shuttle/voidcrew/osprey/cargo/warehouse)
+"lH" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/voidcrew/osprey/maintenance/starboard)
+"lI" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/voidcrew/osprey/service/dormitories)
 "lO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/structure/cable,
@@ -1238,29 +1209,32 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/shuttle/voidcrew/osprey/maintenance/starboard)
 "lT" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/station/science/robotics/lab)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "lU" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /turf/open/floor/engine/hull,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
+"lW" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/voidcrew/osprey/maintenance/port)
 "lX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/layer3,
 /obj/effect/turf_decal/stripes,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "lY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/station/science/robotics/lab)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "md" = (
 /obj/machinery/door/airlock/maintenance/external,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
@@ -1268,7 +1242,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/station/hallway/primary/starboard)
+/area/shuttle/voidcrew/osprey/hallway/starboard)
+"mf" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/voidcrew/osprey/research)
 "mj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/cable,
@@ -1284,7 +1261,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "mk" = (
 /obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/tile/red/half/contrasted,
@@ -1295,7 +1272,7 @@
 	dir = 8
 	},
 /turf/open/floor/circuit/off,
-/area/station/science/robotics/lab)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "ml" = (
 /obj/structure/cable,
 /obj/machinery/power/port_gen/pacman/pre_loaded,
@@ -1303,14 +1280,14 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "mn" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /turf/open/floor/engine/hull,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "mo" = (
 /obj/structure/cable,
 /obj/machinery/light{
@@ -1320,13 +1297,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/junction/flip,
 /turf/open/floor/catwalk_floor/iron,
-/area/station/hallway/primary/aft)
-"mp" = (
-/obj/machinery/power/shuttle_engine/ship/fueled/plasma{
-	dir = 1
-	},
+/area/shuttle/voidcrew/osprey/hallway/aft)
+"mt" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
-/area/station/maintenance/port)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "mv" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay"
@@ -1341,10 +1316,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/cargo/office)
-"mE" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/station/commons/dorms)
+/area/shuttle/voidcrew/osprey/cargo/warehouse)
 "mI" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -1354,7 +1326,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
-/area/station/hallway/primary/starboard)
+/area/shuttle/voidcrew/osprey/hallway/starboard)
 "mJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1363,7 +1335,7 @@
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/bin,
 /turf/open/floor/iron,
-/area/station/cargo/office)
+/area/shuttle/voidcrew/osprey/cargo)
 "mQ" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/light{
@@ -1371,7 +1343,7 @@
 	},
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/open/floor/iron/dark,
-/area/station/cargo/miningoffice)
+/area/shuttle/voidcrew/osprey/cargo/mining_dock)
 "mR" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -1380,7 +1352,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/hallway/primary/port)
+/area/shuttle/voidcrew/osprey/hallway/port)
 "mV" = (
 /obj/effect/turf_decal/siding/thinplating_new/light{
 	dir = 1
@@ -1391,23 +1363,23 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/station/science/robotics/lab)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "na" = (
 /obj/effect/landmark/start/scientist,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/science/research)
+/area/shuttle/voidcrew/osprey/research)
 "nh" = (
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
-/area/station/maintenance/port)
+/area/shuttle/voidcrew/osprey/maintenance/port)
 "nk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/shuttle/voidcrew/osprey/medbay)
 "nl" = (
 /obj/machinery/light{
 	dir = 4
@@ -1419,13 +1391,13 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/area/shuttle/voidcrew/osprey/hallway/port)
 "nn" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/shuttle/voidcrew/osprey/hallway/starboard)
 "no" = (
 /obj/structure/cable,
 /obj/structure/window/reinforced/plasma/spawner,
@@ -1438,7 +1410,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/port)
+/area/shuttle/voidcrew/osprey/maintenance/port)
 "ns" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /obj/machinery/door/poddoor/shutters{
@@ -1447,21 +1419,25 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "nu" = (
 /obj/effect/spawner/random/maintenance/three,
 /obj/structure/closet/cardboard{
 	name = "forgotten IKEA box"
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/port)
+/area/shuttle/voidcrew/osprey/maintenance/port)
+"nG" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/turf/open/floor/plating,
+/area/shuttle/voidcrew/osprey/engineering)
 "nI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/station/hallway/primary/starboard)
+/area/shuttle/voidcrew/osprey/hallway/starboard)
 "nK" = (
 /obj/item/bodypart/chest/robot,
 /obj/item/bodypart/head/robot,
@@ -1481,7 +1457,7 @@
 /obj/item/bodypart/arm/right/robot,
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron,
-/area/station/science/robotics/lab)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "nM" = (
 /obj/structure/table,
 /obj/item/clothing/glasses/welding,
@@ -1493,7 +1469,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/station/science/robotics/lab)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "nO" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/glass/fifty,
@@ -1501,7 +1477,7 @@
 /obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/smooth,
-/area/station/cargo/warehouse)
+/area/shuttle/voidcrew/osprey/cargo/warehouse)
 "nS" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -1512,32 +1488,29 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
-/area/station/commons/dorms)
-"nT" = (
-/turf/closed/wall/mineral/titanium,
-/area/station/hallway/primary/starboard)
+/area/shuttle/voidcrew/osprey/service/dormitories)
 "oa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
-/area/station/medical/medbay/lobby)
+/area/shuttle/voidcrew/osprey/medbay)
 "ob" = (
 /obj/structure/filingcabinet,
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/carpet,
-/area/station/commons/dorms)
+/area/shuttle/voidcrew/osprey/service/dormitories)
 "og" = (
 /turf/open/floor/catwalk_floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "ok" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/junction,
 /turf/open/floor/wood,
-/area/station/medical/medbay/lobby)
+/area/shuttle/voidcrew/osprey/medbay/lobby)
 "op" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable,
@@ -1545,39 +1518,35 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/shuttle/voidcrew/osprey/maintenance/starboard)
 "ow" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "ox" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/area/shuttle/voidcrew/osprey/hallway/port)
 "oy" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/shuttle/voidcrew/osprey/maintenance/starboard)
 "oA" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
 /obj/machinery/door/airlock/external/glass,
-/obj/docking_port/mobile/voidcrew{
-	dir = 4;
-	launch_status = 0;
-	port_direction = 8
-	},
 /obj/effect/turf_decal/stripes{
 	dir = 8
 	},
+/obj/docking_port/mobile/voidcrew/osprey,
 /turf/open/floor/plating,
-/area/station/maintenance/port)
+/area/shuttle/voidcrew/osprey/hallway/port)
 "oE" = (
 /obj/structure/cable,
 /obj/machinery/light{
@@ -1591,7 +1560,7 @@
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high,
 /turf/open/floor/iron,
-/area/station/cargo/office)
+/area/shuttle/voidcrew/osprey/cargo)
 "oI" = (
 /obj/machinery/light{
 	dir = 1
@@ -1605,7 +1574,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "oK" = (
 /obj/machinery/firealarm/directional/west,
 /obj/structure/cable,
@@ -1615,7 +1584,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/wood,
-/area/station/command/heads_quarters/qm)
+/area/shuttle/voidcrew/osprey/cargo/quartermaster)
 "oL" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/visible{
 	dir = 4
@@ -1624,7 +1593,15 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/engineering/atmos)
+/area/shuttle/voidcrew/osprey/engineering/atmospherics)
+"oN" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	id = "ospreywindows";
+	name = "Blast Shutters"
+	},
+/turf/open/floor/plating,
+/area/shuttle/voidcrew/osprey/service/cafeteria)
 "oO" = (
 /obj/effect/decal/cleanable/oil,
 /obj/item/radio/intercom/directional/west{
@@ -1635,18 +1612,21 @@
 /obj/effect/spawner/random/maintenance,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/station/science/robotics/lab)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "oP" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate/internals,
 /turf/open/floor/iron/smooth,
-/area/station/cargo/warehouse)
+/area/shuttle/voidcrew/osprey/cargo/warehouse)
+"oQ" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/voidcrew/osprey/research)
 "oR" = (
 /obj/machinery/status_display/shuttle{
 	pixel_y = 32
 	},
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/station/command/heads_quarters/qm)
+/area/shuttle/voidcrew/osprey/cargo/quartermaster)
 "oW" = (
 /obj/machinery/door/airlock/command{
 	name = "Quartermaster's Office"
@@ -1658,7 +1638,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
-/area/station/command/heads_quarters/qm)
+/area/shuttle/voidcrew/osprey/cargo/quartermaster)
+"oX" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/voidcrew/osprey/cargo/mining_dock)
+"pa" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/stack/tile/iron/dark,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/shuttle/voidcrew/osprey/hallway/starboard)
 "pf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/cable,
@@ -1671,18 +1663,21 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "pi" = (
 /obj/structure/mecha_wreckage/ripley,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/recharge_floor,
-/area/station/science/robotics/lab)
+/area/shuttle/voidcrew/osprey/research/robotics)
+"pk" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/voidcrew/osprey/engineering/atmospherics)
 "pr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/junction/flip,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/shuttle/voidcrew/osprey/hallway/central)
 "ps" = (
 /obj/item/food/canned/beans{
 	pixel_x = -5;
@@ -1718,20 +1713,34 @@
 /obj/item/food/rationpack,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/smooth,
-/area/station/cargo/warehouse)
+/area/shuttle/voidcrew/osprey/cargo/warehouse)
+"px" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	id = "ospreywindows";
+	name = "Blast Shutters"
+	},
+/turf/open/floor/plating,
+/area/shuttle/voidcrew/osprey/cargo/warehouse)
+"pB" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/voidcrew/osprey/hallway/port)
 "pC" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes,
 /turf/open/floor/plating,
-/area/station/engineering/atmos)
+/area/shuttle/voidcrew/osprey/engineering/atmospherics)
 "pE" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/shuttle/voidcrew/osprey/hallway/central)
 "pF" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
@@ -1739,17 +1748,11 @@
 /obj/effect/turf_decal/siding/thinplating_new,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/circuit/off,
-/area/station/science/robotics/lab)
-"pJ" = (
+/area/shuttle/voidcrew/osprey/research/robotics)
+"pI" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
-/area/station/commons/dorms)
-"pO" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/station/hallway/primary/aft)
-"pT" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/station/service/janitor)
+/area/shuttle/voidcrew/osprey/service/dormitories)
 "pU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1758,13 +1761,14 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/station/service/cafeteria)
-"pY" = (
-/turf/closed/wall/mineral/titanium,
-/area/station/command/heads_quarters/qm)
+/area/shuttle/voidcrew/osprey/service/cafeteria)
+"pV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/voidcrew/osprey/maintenance/starboard)
 "qa" = (
 /turf/open/floor/plating,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "qc" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
@@ -1775,7 +1779,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/circuit/off,
-/area/station/science/robotics/lab)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "qe" = (
 /obj/machinery/autolathe,
 /obj/effect/turf_decal/tile/purple{
@@ -1786,10 +1790,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark/textured,
-/area/station/science/research)
-"qf" = (
-/turf/closed/wall/mineral/titanium,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/research)
 "qg" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes{
@@ -1800,20 +1801,14 @@
 	dir = 2
 	},
 /turf/open/floor/iron,
-/area/station/science/robotics/lab)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "qj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/junction/yjunction,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
-"qn" = (
-/turf/closed/wall/mineral/titanium,
-/area/station/command/bridge)
-"qq" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/station/engineering/atmos)
+/area/shuttle/voidcrew/osprey/hallway/central)
 "qy" = (
 /obj/structure/sink/directional/south,
 /obj/structure/mirror{
@@ -1821,16 +1816,7 @@
 	},
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/dark,
-/area/station/commons/dorms)
-"qA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/stack/tile/iron/dark,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/station/hallway/primary/starboard)
+/area/shuttle/voidcrew/osprey/service/dormitories)
 "qC" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=med";
@@ -1839,7 +1825,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/station/cargo/warehouse)
+/area/shuttle/voidcrew/osprey/cargo/warehouse)
 "qD" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
@@ -1847,18 +1833,18 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/station/maintenance/port)
+/area/shuttle/voidcrew/osprey/hallway/port)
 "qK" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 2
 	},
 /obj/machinery/disposal/bin,
 /turf/open/floor/wood,
-/area/station/service/cafeteria)
+/area/shuttle/voidcrew/osprey/service/cafeteria)
 "qO" = (
 /obj/structure/frame/machine,
 /turf/open/floor/iron/dark,
-/area/station/science/robotics/lab)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "qP" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -1867,21 +1853,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
-/area/station/cargo/warehouse)
+/area/shuttle/voidcrew/osprey/cargo/warehouse)
 "qT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_white,
-/area/station/science/robotics/lab)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "qZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_smooth,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "rb" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/shuttle/voidcrew/osprey/hallway/central)
 "rh" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1890,10 +1876,10 @@
 	dir = 2
 	},
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "rj" = (
 /turf/open/floor/wood,
-/area/station/service/cafeteria)
+/area/shuttle/voidcrew/osprey/service/cafeteria)
 "rm" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/machinery/light/small{
@@ -1901,14 +1887,14 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
-/area/station/service/janitor)
+/area/shuttle/voidcrew/osprey/service/janitor)
 "rn" = (
 /obj/machinery/vending/wardrobe/cargo_wardrobe,
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 8
 	},
 /turf/open/floor/iron/smooth,
-/area/station/cargo/office)
+/area/shuttle/voidcrew/osprey/cargo)
 "rq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1917,7 +1903,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/station/command/bridge)
+/area/shuttle/voidcrew/osprey/bridge)
 "rs" = (
 /obj/structure/sign/poster/official/random/directional/west,
 /obj/structure/frame/computer{
@@ -1925,7 +1911,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/science/robotics/lab)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "ru" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -1938,12 +1924,12 @@
 /obj/structure/bedsheetbin,
 /obj/structure/table/wood,
 /turf/open/floor/iron/grimy,
-/area/station/commons/dorms)
+/area/shuttle/voidcrew/osprey/service/dormitories)
 "rv" = (
 /obj/effect/landmark/start/cook,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron/showroomfloor,
-/area/station/service/cafeteria)
+/area/shuttle/voidcrew/osprey/service/cafeteria)
 "rD" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/chair/office{
@@ -1954,7 +1940,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/station/cargo/warehouse)
+/area/shuttle/voidcrew/osprey/cargo/warehouse)
 "rF" = (
 /obj/structure/table,
 /obj/effect/turf_decal/siding/red{
@@ -1964,17 +1950,14 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/robotics/lab)
-"rM" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/station/maintenance/port)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "rN" = (
 /obj/structure/sign/nanotrasen{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "rW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1984,7 +1967,7 @@
 	},
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/catwalk_floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "rX" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -1992,10 +1975,7 @@
 /obj/machinery/light,
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
-/area/station/science/robotics/lab)
-"sf" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/station/medical/medbay/lobby)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "sl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2004,23 +1984,31 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
-/area/station/hallway/primary/port)
-"sn" = (
+/area/shuttle/voidcrew/osprey/hallway/port)
+"sr" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/voidcrew/osprey/medbay/lobby)
+"su" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /obj/machinery/door/poddoor/shutters{
 	id = "ospreywindows";
 	name = "Blast Shutters"
 	},
 /turf/open/floor/plating,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/cargo/quartermaster)
+"sv" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	id = "ospreywindows";
+	name = "Blast Shutters"
+	},
+/turf/open/floor/plating,
+/area/shuttle/voidcrew/osprey/engineering)
 "sw" = (
 /obj/structure/cable,
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
-/area/station/engineering/main)
-"sB" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/station/command/bridge)
+/area/shuttle/voidcrew/osprey/engineering)
 "sG" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Canteen"
@@ -2029,11 +2017,11 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/service/cafeteria)
+/area/shuttle/voidcrew/osprey/service/cafeteria)
 "sH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/station/maintenance/starboard)
+/area/shuttle/voidcrew/osprey/hallway/port)
 "sM" = (
 /obj/machinery/light,
 /obj/machinery/status_display/shuttle{
@@ -2047,22 +2035,22 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/smooth,
-/area/station/cargo/warehouse)
+/area/shuttle/voidcrew/osprey/cargo/warehouse)
 "sN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "sU" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "ospreybridge"
 	},
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "sZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood,
-/area/station/service/cafeteria)
+/area/shuttle/voidcrew/osprey/service/cafeteria)
 "ta" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2071,35 +2059,27 @@
 	dir = 8
 	},
 /turf/open/floor/iron/grimy,
-/area/station/commons/dorms)
+/area/shuttle/voidcrew/osprey/service/dormitories)
 "tc" = (
 /obj/effect/turf_decal/stripes{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "td" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "ospreybridge"
 	},
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
-/area/station/command/bridge)
-"te" = (
-/obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor/shutters{
-	id = "ospreywindows";
-	name = "Blast Shutters"
-	},
-/turf/open/floor/plating,
-/area/station/commons/dorms)
+/area/shuttle/voidcrew/osprey/bridge)
 "tf" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/shuttle/voidcrew/osprey/hallway/central)
 "tj" = (
 /obj/structure/sign/nanotrasen{
 	pixel_y = 32
@@ -2108,21 +2088,21 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "tr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/carpet/royalblue,
-/area/station/command/bridge)
+/area/shuttle/voidcrew/osprey/bridge)
 "tF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/shuttle/voidcrew/osprey/maintenance/starboard)
 "tH" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/start/janitor,
@@ -2130,33 +2110,44 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
-/area/station/service/janitor)
+/area/shuttle/voidcrew/osprey/service/janitor)
+"tI" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/voidcrew/osprey/research/robotics)
+"tM" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/voidcrew/osprey/medbay)
 "tO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/shuttle/voidcrew/osprey/medbay)
 "tV" = (
 /obj/structure/table_frame,
 /obj/effect/turf_decal/tile/red/diagonal_centre,
 /turf/open/floor/iron/white/diagonal,
-/area/station/science/robotics/lab)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "tW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
 /obj/effect/turf_decal/stripes{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/engineering/atmos)
+/area/shuttle/voidcrew/osprey/engineering/atmospherics)
 "tX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/port)
+/area/shuttle/voidcrew/osprey/maintenance/port)
+"ue" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/shuttle/voidcrew/osprey/cargo/mining_dock)
 "uf" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2166,7 +2157,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "ug" = (
 /obj/item/radio/intercom/directional/east,
 /obj/machinery/computer/cargo/express{
@@ -2174,7 +2165,7 @@
 	},
 /obj/structure/sign/poster/official/random/directional/south,
 /turf/open/floor/wood,
-/area/station/cargo/warehouse)
+/area/shuttle/voidcrew/osprey/cargo/warehouse)
 "ui" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Laboratory"
@@ -2182,7 +2173,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /turf/open/floor/iron/dark,
-/area/station/science/robotics/lab)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "un" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2190,18 +2181,18 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
-/area/station/science/research)
+/area/shuttle/voidcrew/osprey/research)
 "up" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
-/area/station/science/research)
+/area/shuttle/voidcrew/osprey/research)
 "ut" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron,
-/area/station/cargo/office)
+/area/shuttle/voidcrew/osprey/cargo)
 "uu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange,
 /obj/machinery/light/small{
@@ -2209,17 +2200,17 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
-"uD" = (
-/turf/closed/wall/mineral/titanium,
-/area/station/science/research)
+/area/shuttle/voidcrew/osprey/maintenance/starboard)
+"uA" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/voidcrew/osprey/hallway/port)
 "uE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
-/area/station/science/research)
+/area/shuttle/voidcrew/osprey/research)
 "uH" = (
 /obj/structure/filingcabinet,
 /obj/structure/extinguisher_cabinet/directional/south,
@@ -2232,7 +2223,18 @@
 /turf/open/floor/iron/dark/smooth_corner{
 	dir = 8
 	},
-/area/station/command/bridge)
+/area/shuttle/voidcrew/osprey/bridge)
+"uK" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	id = "ospreywindows";
+	name = "Blast Shutters"
+	},
+/turf/open/floor/plating,
+/area/shuttle/voidcrew/osprey/medbay/lobby)
+"uL" = (
+/turf/open/floor/iron/white,
+/area/shuttle/voidcrew/osprey/research)
 "uP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/cable,
@@ -2245,7 +2247,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/area/shuttle/voidcrew/osprey/hallway/port)
 "uY" = (
 /obj/effect/decal/cleanable/oil/streak,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -2259,13 +2261,13 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/cargo/office)
+/area/shuttle/voidcrew/osprey/cargo)
 "uZ" = (
 /obj/effect/turf_decal/siding/thinplating_new/light{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/research)
+/area/shuttle/voidcrew/osprey/research)
 "va" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering"
@@ -2275,7 +2277,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "vj" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay"
@@ -2287,7 +2289,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/cargo/office)
+/area/shuttle/voidcrew/osprey/cargo/warehouse)
 "vm" = (
 /obj/structure/table,
 /obj/item/mmi/posibrain,
@@ -2295,7 +2297,7 @@
 	dir = 10
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/robotics/lab)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "vo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/cable,
@@ -2305,21 +2307,22 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
-"vp" = (
-/obj/effect/spawner/structure/window/reinforced/shuttle,
-/turf/open/floor/plating,
-/area/station/command/bridge)
-"vv" = (
-/turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "vz" = (
 /obj/structure/chair{
 	dir = 1
 	},
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/shuttle/voidcrew/osprey/hallway/central)
+"vA" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	id = "ospreywindows";
+	name = "Blast Shutters"
+	},
+/turf/open/floor/plating,
+/area/shuttle/voidcrew/osprey/hallway/central)
 "vB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2329,14 +2332,14 @@
 	},
 /obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/wood,
-/area/station/service/cafeteria)
+/area/shuttle/voidcrew/osprey/service/cafeteria)
 "vD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/shuttle/voidcrew/osprey/hallway/central)
 "vN" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -2351,14 +2354,14 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/cargo/miningoffice)
+/area/shuttle/voidcrew/osprey/cargo/mining_dock)
 "vS" = (
 /obj/machinery/atmospherics/components/tank/plasma{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes,
 /turf/open/floor/plating,
-/area/station/engineering/atmos)
+/area/shuttle/voidcrew/osprey/engineering/atmospherics)
 "vT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2371,7 +2374,7 @@
 	location = "bridge"
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "vW" = (
 /obj/structure/sign/poster/official/random/directional/west,
 /obj/effect/turf_decal/trimline/brown/line{
@@ -2384,7 +2387,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
+/area/shuttle/voidcrew/osprey/cargo/warehouse)
 "we" = (
 /obj/machinery/modular_computer/console/preset/id,
 /obj/effect/turf_decal/tile/dark_blue/half{
@@ -2393,7 +2396,7 @@
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 1
 	},
-/area/station/command/bridge)
+/area/shuttle/voidcrew/osprey/bridge)
 "wi" = (
 /obj/structure/aquarium/prefilled,
 /obj/item/fish_feed{
@@ -2401,13 +2404,13 @@
 	pixel_x = 8
 	},
 /turf/open/floor/wood,
-/area/station/medical/medbay/lobby)
+/area/shuttle/voidcrew/osprey/medbay/lobby)
 "wj" = (
 /obj/effect/turf_decal/trimline/neutral/warning,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/station/cargo/office)
+/area/shuttle/voidcrew/osprey/cargo)
 "wl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2418,25 +2421,22 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "wo" = (
 /obj/effect/turf_decal/stripes{
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
-/area/station/cargo/miningoffice)
-"wt" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/station/command/heads_quarters/qm)
+/area/shuttle/voidcrew/osprey/cargo/mining_dock)
 "wv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/shuttle/voidcrew/osprey/medbay)
 "ww" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
-/area/station/commons/dorms)
+/area/shuttle/voidcrew/osprey/service/dormitories)
 "wP" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -2447,7 +2447,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
-/area/station/hallway/primary/port)
+/area/shuttle/voidcrew/osprey/hallway/port)
 "wV" = (
 /obj/structure/cable,
 /obj/machinery/light{
@@ -2458,15 +2458,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/sign/poster/official/random/directional/west,
 /turf/open/floor/iron/white,
-/area/station/science/research)
-"wW" = (
-/obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor/shutters{
-	id = "ospreywindows";
-	name = "Blast Shutters"
-	},
-/turf/open/floor/plating,
-/area/station/command/heads_quarters/qm)
+/area/shuttle/voidcrew/osprey/research)
 "wY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/cable,
@@ -2476,27 +2468,31 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "xh" = (
 /turf/closed/wall/mineral/titanium/interior,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "xi" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/carpet,
-/area/station/commons/dorms)
+/area/shuttle/voidcrew/osprey/service/dormitories)
+"xk" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/turf/open/floor/plating,
+/area/shuttle/voidcrew/osprey/cargo/warehouse)
 "xw" = (
 /obj/machinery/atmospherics/components/binary/pump,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/station/maintenance/port)
+/area/shuttle/voidcrew/osprey/maintenance/port)
 "xx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/station/cargo/warehouse)
+/area/shuttle/voidcrew/osprey/cargo/warehouse)
 "xM" = (
 /obj/structure/cable,
 /obj/machinery/navbeacon{
@@ -2504,7 +2500,7 @@
 	location = "med"
 	},
 /turf/open/floor/wood,
-/area/station/medical/medbay/lobby)
+/area/shuttle/voidcrew/osprey/medbay/lobby)
 "xS" = (
 /obj/machinery/light{
 	dir = 4
@@ -2513,18 +2509,18 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/science/robotics/lab)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "xV" = (
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/wood,
-/area/station/service/cafeteria)
+/area/shuttle/voidcrew/osprey/service/cafeteria)
 "yj" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/station/medical/medbay/lobby)
+/area/shuttle/voidcrew/osprey/medbay/lobby)
 "ym" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/cable,
@@ -2537,28 +2533,28 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
+"yx" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/voidcrew/osprey/engineering/atmospherics)
 "yB" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
-"yG" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/station/cargo/warehouse)
-"yU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/station/hallway/primary/port)
+/area/shuttle/voidcrew/osprey/hallway/central)
+"yE" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/voidcrew/osprey/cargo/quartermaster)
 "yV" = (
 /obj/effect/turf_decal/siding/thinplating_new/light,
 /turf/open/floor/iron/dark,
-/area/station/science/research)
+/area/shuttle/voidcrew/osprey/research)
+"yX" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/shuttle/voidcrew/osprey/engineering)
 "yZ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/fax{
@@ -2572,10 +2568,15 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/smooth_corner,
-/area/station/command/bridge)
-"zb" = (
-/turf/open/floor/iron,
-/area/station/cargo/office)
+/area/shuttle/voidcrew/osprey/bridge)
+"ze" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	id = "ospreywindows";
+	name = "Blast Shutters"
+	},
+/turf/open/floor/plating,
+/area/shuttle/voidcrew/osprey/service/janitor)
 "zh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2584,7 +2585,7 @@
 	location = "dorms"
 	},
 /turf/open/floor/iron/grimy,
-/area/station/commons/dorms)
+/area/shuttle/voidcrew/osprey/service/dormitories)
 "zk" = (
 /obj/structure/table,
 /obj/item/storage/box/mousetraps,
@@ -2593,7 +2594,7 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
-/area/station/service/janitor)
+/area/shuttle/voidcrew/osprey/service/janitor)
 "zm" = (
 /obj/machinery/button/door{
 	dir = 8;
@@ -2606,13 +2607,13 @@
 	pixel_y = -9
 	},
 /turf/open/floor/iron/white,
-/area/station/science/research)
+/area/shuttle/voidcrew/osprey/research)
 "zs" = (
 /obj/structure/chair/office,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/dark/diagonal_centre,
 /turf/open/floor/iron/white/diagonal,
-/area/station/science/robotics/lab)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "zv" = (
 /obj/effect/turf_decal/trimline/brown/line{
 	dir = 8
@@ -2621,7 +2622,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
+/area/shuttle/voidcrew/osprey/cargo/warehouse)
 "zz" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 32
@@ -2630,7 +2631,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/port)
+/area/shuttle/voidcrew/osprey/maintenance/port)
 "zF" = (
 /obj/structure/closet/secure_closet/quartermaster,
 /obj/structure/window/reinforced/survival_pod{
@@ -2640,14 +2641,11 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/orange,
-/area/station/command/heads_quarters/qm)
-"zI" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/station/science/robotics/lab)
+/area/shuttle/voidcrew/osprey/cargo/quartermaster)
 "zJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/station/cargo/miningoffice)
+/area/shuttle/voidcrew/osprey/cargo/mining_dock)
 "zL" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -2657,16 +2655,12 @@
 	pixel_x = -32
 	},
 /turf/open/floor/iron/dark,
-/area/station/hallway/primary/starboard)
-"zQ" = (
-/obj/effect/spawner/structure/window/reinforced/shuttle,
-/turf/open/floor/plating,
-/area/station/service/cafeteria)
+/area/shuttle/voidcrew/osprey/hallway/starboard)
 "zW" = (
 /obj/machinery/pdapainter,
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/carpet/blue,
-/area/station/command/bridge)
+/area/shuttle/voidcrew/osprey/bridge)
 "Ac" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2675,7 +2669,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/shuttle/voidcrew/osprey/hallway/central)
 "Am" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/navbeacon{
@@ -2683,7 +2677,7 @@
 	location = "rnd"
 	},
 /turf/open/floor/catwalk_floor/iron_white,
-/area/station/science/robotics/lab)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "Av" = (
 /obj/structure/table,
 /obj/effect/turf_decal/siding/red,
@@ -2702,7 +2696,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/station/science/robotics/lab)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "Aw" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -2710,7 +2704,7 @@
 /obj/structure/sign/warning/electric_shock/directional/east,
 /obj/structure/tank_dispenser,
 /turf/open/floor/iron/smooth_large,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "Ax" = (
 /obj/effect/landmark/start/scientist,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -2718,7 +2712,7 @@
 	},
 /obj/structure/chair/stool,
 /turf/open/floor/iron/white,
-/area/station/science/research)
+/area/shuttle/voidcrew/osprey/research)
 "AD" = (
 /obj/machinery/light,
 /obj/machinery/status_display/shuttle{
@@ -2728,10 +2722,10 @@
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/station/service/cafeteria)
+/area/shuttle/voidcrew/osprey/service/cafeteria)
 "AH" = (
 /turf/open/floor/iron/grimy,
-/area/station/commons/dorms)
+/area/shuttle/voidcrew/osprey/service/dormitories)
 "AK" = (
 /obj/effect/turf_decal/trimline/neutral/warning,
 /obj/machinery/button/door{
@@ -2747,7 +2741,7 @@
 	pixel_x = 6
 	},
 /turf/open/floor/iron/textured_large,
-/area/station/cargo/office)
+/area/shuttle/voidcrew/osprey/cargo)
 "AL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2756,14 +2750,14 @@
 	},
 /obj/effect/turf_decal/stripes,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "AM" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "AP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2778,13 +2772,13 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/commons/dorms)
+/area/shuttle/voidcrew/osprey/service/dormitories)
 "AW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
 /turf/open/floor/carpet/blue,
-/area/station/command/bridge)
+/area/shuttle/voidcrew/osprey/bridge)
 "AZ" = (
 /obj/structure/tank_dispenser/oxygen,
 /obj/structure/sign/poster/official/safety_internals{
@@ -2792,7 +2786,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
-/area/station/hallway/primary/starboard)
+/area/shuttle/voidcrew/osprey/hallway/starboard)
 "Bl" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Infirmary"
@@ -2801,7 +2795,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/shuttle/voidcrew/osprey/medbay)
 "Bq" = (
 /obj/machinery/status_display/shuttle{
 	pixel_y = 32
@@ -2809,11 +2803,10 @@
 /obj/structure/closet/secure_closet/miner/unlocked,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
-/area/station/cargo/miningoffice)
-"Bs" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/cargo/mining_dock)
+"Bz" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/voidcrew/osprey/research/robotics)
 "BC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/cable,
@@ -2827,35 +2820,33 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
+"BD" = (
+/turf/open/floor/iron,
+/area/shuttle/voidcrew/osprey/cargo)
 "BG" = (
 /obj/machinery/airalarm/directional/east,
 /obj/structure/chair/sofa/bench/right{
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/station/medical/medbay/lobby)
+/area/shuttle/voidcrew/osprey/medbay/lobby)
 "BM" = (
 /obj/structure/chair/office{
 	dir = 4
 	},
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
-"BR" = (
-/obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor/shutters{
-	id = "ospreywindows";
-	name = "Blast Shutters"
-	},
-/turf/open/floor/plating,
-/area/station/cargo/office)
+/area/shuttle/voidcrew/osprey/engineering/atmospherics)
+"BQ" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/voidcrew/osprey/bridge)
 "BW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/stairs{
 	dir = 4
 	},
-/area/station/command/bridge)
+/area/shuttle/voidcrew/osprey/bridge)
 "Cb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -2864,12 +2855,12 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/science/robotics/lab)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "Cd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/station/cargo/warehouse)
+/area/shuttle/voidcrew/osprey/cargo/warehouse)
 "Cf" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -2886,7 +2877,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/sign/departments/science/alt/directional/west,
 /turf/open/floor/iron,
-/area/station/science/research)
+/area/shuttle/voidcrew/osprey/research)
 "Ch" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/cable,
@@ -2897,18 +2888,18 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/shuttle/voidcrew/osprey/hallway/starboard)
 "Ck" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/maintenance,
 /obj/effect/spawner/random/maintenance,
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/shuttle/voidcrew/osprey/maintenance/starboard)
 "Cm" = (
 /obj/effect/turf_decal/bot/left,
 /turf/open/floor/iron/dark,
-/area/station/cargo/miningoffice)
+/area/shuttle/voidcrew/osprey/cargo/mining_dock)
 "Cn" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/heavy,
@@ -2920,14 +2911,14 @@
 	id = "ospreycargo"
 	},
 /turf/open/floor/iron,
-/area/station/cargo/office)
+/area/shuttle/voidcrew/osprey/cargo)
 "Cr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/shuttle/voidcrew/osprey/cargo)
 "Ct" = (
 /obj/structure/cable,
 /obj/structure/table,
@@ -2951,7 +2942,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/science/research)
+/area/shuttle/voidcrew/osprey/research)
 "CA" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /obj/machinery/door/poddoor/shutters{
@@ -2959,14 +2950,14 @@
 	name = "Blast Shutters"
 	},
 /turf/open/floor/plating,
-/area/station/hallway/primary/central)
+/area/shuttle/voidcrew/osprey/research)
 "CI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/station/engineering/atmos)
+/area/shuttle/voidcrew/osprey/engineering/atmospherics)
 "CQ" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -2983,7 +2974,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/cargo/office)
+/area/shuttle/voidcrew/osprey/cargo)
 "CR" = (
 /obj/effect/turf_decal/stripes{
 	dir = 8
@@ -2992,7 +2983,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/smooth,
-/area/station/cargo/warehouse)
+/area/shuttle/voidcrew/osprey/cargo/warehouse)
 "CW" = (
 /obj/item/trash/cheesie,
 /obj/effect/turf_decal/tile/red/opposingcorners,
@@ -3001,17 +2992,17 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/circuit/off,
-/area/station/science/robotics/lab)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "Dc" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/shuttle/voidcrew/osprey/medbay)
 "Dg" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/light,
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/shuttle/voidcrew/osprey/hallway/central)
 "Di" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/light,
@@ -3019,13 +3010,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
-"Do" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/station/medical/medbay/central)
-"Dp" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/station/cargo/miningoffice)
+/area/shuttle/voidcrew/osprey/hallway/central)
 "Ds" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -3034,7 +3019,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/science/robotics/lab)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "Dw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -3043,7 +3028,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/station/service/janitor)
+/area/shuttle/voidcrew/osprey/service/janitor)
 "Dz" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -3054,25 +3039,25 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/shuttle/voidcrew/osprey/hallway/starboard)
 "DC" = (
 /obj/machinery/atmospherics/components/binary/pump,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/shuttle/voidcrew/osprey/maintenance/starboard)
 "DD" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/port)
+/area/shuttle/voidcrew/osprey/hallway/starboard)
 "DG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/item/analyzer,
 /obj/effect/turf_decal/stripes,
 /turf/open/floor/plating,
-/area/station/engineering/atmos)
+/area/shuttle/voidcrew/osprey/engineering/atmospherics)
 "DI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3084,23 +3069,19 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/port)
+/area/shuttle/voidcrew/osprey/maintenance/port)
 "DP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/light/small,
 /turf/open/floor/plating,
-/area/station/engineering/atmos)
+/area/shuttle/voidcrew/osprey/engineering/atmospherics)
 "DQ" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/station/service/cafeteria)
+/area/shuttle/voidcrew/osprey/service/cafeteria)
 "DX" = (
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/station/medical/medbay/lobby)
-"Ed" = (
-/obj/effect/spawner/structure/window/reinforced/shuttle,
-/turf/open/floor/plating,
-/area/station/medical/medbay/lobby)
+/area/shuttle/voidcrew/osprey/medbay)
 "Ei" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/cable,
@@ -3116,7 +3097,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "Eo" = (
 /obj/machinery/light/small,
 /obj/structure/table,
@@ -3125,11 +3106,11 @@
 /obj/machinery/firealarm/directional/south,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
-/area/station/service/janitor)
+/area/shuttle/voidcrew/osprey/service/janitor)
 "Ep" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
-/area/station/service/cafeteria)
+/area/shuttle/voidcrew/osprey/service/cafeteria)
 "Er" = (
 /obj/machinery/computer/operating,
 /obj/machinery/airalarm/directional/west,
@@ -3137,14 +3118,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/medical/medbay/central)
-"Eu" = (
-/obj/structure/cable,
-/obj/machinery/power/shuttle_engine/ship/electric{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/shuttle/voidcrew/osprey/medbay)
 "Ev" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3153,7 +3127,7 @@
 	pixel_x = 32
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "EB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange,
 /obj/machinery/light/small{
@@ -3161,7 +3135,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/station/maintenance/port)
+/area/shuttle/voidcrew/osprey/maintenance/port)
 "ED" = (
 /obj/machinery/light{
 	dir = 8
@@ -3171,20 +3145,24 @@
 	},
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/shuttle/voidcrew/osprey/medbay)
+"EE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/turf/open/floor/plating,
+/area/shuttle/voidcrew/osprey/maintenance/starboard)
 "EL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "EO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/station/science/research)
+/area/shuttle/voidcrew/osprey/research)
 "EQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3192,12 +3170,12 @@
 	dir = 5
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "ER" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "ES" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -3209,7 +3187,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/cargo/office)
+/area/shuttle/voidcrew/osprey/cargo)
 "EW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/cable,
@@ -3222,7 +3200,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "Fb" = (
 /obj/structure/bed/pod,
 /obj/item/bedsheet/qm,
@@ -3232,7 +3210,7 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/orange,
-/area/station/command/heads_quarters/qm)
+/area/shuttle/voidcrew/osprey/cargo/quartermaster)
 "Fn" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -3240,13 +3218,13 @@
 /obj/effect/landmark/start/paramedic,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/shuttle/voidcrew/osprey/medbay)
 "Ft" = (
 /obj/structure/chair{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/shuttle/voidcrew/osprey/hallway/central)
 "Fu" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -3257,7 +3235,7 @@
 	},
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/smooth_large,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "Fy" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -3270,7 +3248,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron,
-/area/station/medical/medbay/central)
+/area/shuttle/voidcrew/osprey/medbay)
 "FA" = (
 /obj/machinery/computer/med_data/laptop{
 	dir = 8
@@ -3281,7 +3259,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/shuttle/voidcrew/osprey/medbay)
 "FC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3294,7 +3272,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "FE" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "ospreybridge"
@@ -3303,10 +3281,10 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "FG" = (
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/cargo/mining_dock)
 "FL" = (
 /obj/structure/sign/warning/no_smoking/directional/west,
 /obj/structure/closet/secure_closet/medical3,
@@ -3320,7 +3298,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/medical/medbay/central)
+/area/shuttle/voidcrew/osprey/medbay)
 "FO" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/condiment/peppermill{
@@ -3340,7 +3318,7 @@
 	pixel_y = 7
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/service/cafeteria)
+/area/shuttle/voidcrew/osprey/service/cafeteria)
 "Gb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/machinery/light/small{
@@ -3348,7 +3326,7 @@
 	},
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/plating,
-/area/station/maintenance/port)
+/area/shuttle/voidcrew/osprey/maintenance/port)
 "Gf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/cable,
@@ -3359,7 +3337,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/shuttle/voidcrew/osprey/hallway/starboard)
 "Gn" = (
 /obj/effect/decal/cleanable/oil/streak,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -3369,13 +3347,13 @@
 	dir = 8
 	},
 /turf/open/floor/circuit/off,
-/area/station/science/robotics/lab)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "Gp" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/airalarm/directional/west,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
-/area/station/hallway/primary/starboard)
+/area/shuttle/voidcrew/osprey/hallway/starboard)
 "Gv" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Laboratory"
@@ -3384,7 +3362,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/station/science/research)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "Gw" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Infirmary"
@@ -3396,25 +3374,22 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/shuttle/voidcrew/osprey/medbay)
 "Gy" = (
 /obj/effect/turf_decal/bot_white/right,
 /turf/open/floor/iron/dark,
-/area/station/cargo/miningoffice)
-"GD" = (
-/turf/closed/wall/mineral/titanium,
-/area/station/medical/medbay/lobby)
+/area/shuttle/voidcrew/osprey/cargo/mining_dock)
 "Hd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/item/radio/intercom/directional/north,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
-/area/station/hallway/primary/starboard)
+/area/shuttle/voidcrew/osprey/hallway/starboard)
 "He" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/shuttle/voidcrew/osprey/maintenance/starboard)
 "Hh" = (
 /obj/machinery/light,
 /obj/structure/cable/layer3,
@@ -3425,46 +3400,42 @@
 /obj/effect/decal/cleanable/oil/streak,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "Hp" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/medbay)
 "Hq" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/shuttle/voidcrew/osprey/hallway/central)
 "Hs" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/station/service/cafeteria)
+/area/shuttle/voidcrew/osprey/service/cafeteria)
 "Hv" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "HB" = (
 /obj/structure/closet,
 /obj/item/stack/sheet/mineral/plasma/thirty,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
-"HD" = (
-/obj/structure/sign/departments/medbay/alt,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/engineering)
 "HE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/catwalk_floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "HF" = (
 /obj/machinery/computer/rdconsole,
 /obj/effect/turf_decal/tile/dark_blue/half{
@@ -3473,7 +3444,14 @@
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 1
 	},
-/area/station/command/bridge)
+/area/shuttle/voidcrew/osprey/bridge)
+"HH" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/shuttle/voidcrew/osprey/hallway/central)
 "HM" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -3481,34 +3459,32 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/circuit/off,
-/area/station/science/robotics/lab)
-"HS" = (
-/turf/closed/wall/mineral/titanium,
-/area/station/service/cafeteria)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "HV" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "HZ" = (
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/plating,
-/area/station/engineering/atmos)
-"Id" = (
+/area/shuttle/voidcrew/osprey/engineering/atmospherics)
+"Ig" = (
+/obj/machinery/door/airlock/maintenance/external,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/station/maintenance/port)
-"If" = (
-/turf/closed/wall/mineral/titanium,
-/area/station/commons/dorms)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/shuttle/voidcrew/osprey/hallway/port)
 "Im" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/station/medical/medbay/lobby)
+/area/shuttle/voidcrew/osprey/medbay/lobby)
 "Ir" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/public/glass{
@@ -3516,11 +3492,11 @@
 	},
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/iron,
-/area/station/medical/medbay/lobby)
+/area/shuttle/voidcrew/osprey/medbay/lobby)
 "Is" = (
 /obj/effect/turf_decal/tile/dark_blue/diagonal_centre,
 /turf/open/floor/iron/dark,
-/area/station/command/bridge)
+/area/shuttle/voidcrew/osprey/bridge)
 "Ix" = (
 /obj/structure/table,
 /obj/item/folder/yellow,
@@ -3532,7 +3508,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
+/area/shuttle/voidcrew/osprey/engineering/atmospherics)
 "IA" = (
 /obj/machinery/light{
 	dir = 1
@@ -3541,32 +3517,32 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "IB" = (
 /obj/structure/table,
 /obj/item/circuitboard/aicore,
 /obj/effect/turf_decal/siding/red,
 /turf/open/floor/iron/dark,
-/area/station/science/robotics/lab)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "IM" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/port)
+/area/shuttle/voidcrew/osprey/maintenance/port)
 "IN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/station/hallway/primary/starboard)
+/area/shuttle/voidcrew/osprey/hallway/port)
 "IS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "IZ" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/light/small{
@@ -3576,11 +3552,11 @@
 	dir = 4
 	},
 /turf/open/floor/iron/smooth_large,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "Ji" = (
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/station/medical/medbay/lobby)
+/area/shuttle/voidcrew/osprey/medbay/lobby)
 "Jk" = (
 /obj/structure/chair{
 	dir = 4
@@ -3589,7 +3565,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/station/service/cafeteria)
+/area/shuttle/voidcrew/osprey/service/cafeteria)
 "Jn" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -3599,15 +3575,7 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
-"Jt" = (
-/obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor/shutters{
-	id = "ospreywindows";
-	name = "Blast Shutters"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
+/area/shuttle/voidcrew/osprey/cargo/warehouse)
 "Ju" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3619,7 +3587,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/medbay/lobby)
 "JB" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
@@ -3636,7 +3604,7 @@
 	id = "ospreysci"
 	},
 /turf/open/floor/iron,
-/area/station/science/research)
+/area/shuttle/voidcrew/osprey/research)
 "JC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3647,14 +3615,21 @@
 /mob/living/simple_animal/hostile/lizard/wags_his_tail,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
-/area/station/service/janitor)
+/area/shuttle/voidcrew/osprey/service/janitor)
 "JF" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Laboratory"
 	},
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /turf/open/floor/iron/dark,
-/area/station/science/robotics/lab)
+/area/shuttle/voidcrew/osprey/research/robotics)
+"JK" = (
+/obj/structure/cable,
+/obj/machinery/power/shuttle_engine/ship/electric{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/voidcrew/osprey/maintenance/port)
 "JO" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -3668,7 +3643,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/robotics/lab)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "JQ" = (
 /obj/structure/railing,
 /obj/machinery/holopad,
@@ -3677,7 +3652,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/station/command/bridge)
+/area/shuttle/voidcrew/osprey/bridge)
 "JR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3686,7 +3661,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/central)
 "JS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3701,11 +3676,7 @@
 	pixel_x = 7
 	},
 /turf/open/floor/iron,
-/area/station/cargo/office)
-"JU" = (
-/obj/effect/spawner/structure/window/reinforced/shuttle,
-/turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/shuttle/voidcrew/osprey/cargo)
 "JV" = (
 /obj/machinery/light{
 	dir = 1
@@ -3713,7 +3684,7 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "Kd" = (
 /obj/structure/cable,
 /obj/structure/frame/machine,
@@ -3721,14 +3692,17 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/science/research)
+/area/shuttle/voidcrew/osprey/research)
 "Kh" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/wood,
-/area/station/service/cafeteria)
+/area/shuttle/voidcrew/osprey/service/cafeteria)
+"Ki" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/voidcrew/osprey/service/cafeteria)
 "Kl" = (
 /obj/structure/closet/secure_closet{
 	icon_door = "mixed";
@@ -3745,7 +3719,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
-/area/station/service/janitor)
+/area/shuttle/voidcrew/osprey/service/janitor)
 "Ko" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -3754,13 +3728,13 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "Kt" = (
 /obj/effect/turf_decal/stripes{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "Ky" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/vending/wardrobe/science_wardrobe,
@@ -3768,7 +3742,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/research)
+/area/shuttle/voidcrew/osprey/research)
 "KA" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -3778,7 +3752,7 @@
 	dir = 4
 	},
 /turf/open/floor/circuit/off,
-/area/station/science/robotics/lab)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "KE" = (
 /obj/structure/table,
 /obj/item/clipboard,
@@ -3791,17 +3765,31 @@
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/station/command/heads_quarters/qm)
-"KO" = (
+/area/shuttle/voidcrew/osprey/cargo/quartermaster)
+"KI" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
-/area/station/science/robotics/lab)
+/area/shuttle/voidcrew/osprey/service/cafeteria)
+"KL" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/voidcrew/osprey/service/dormitories)
+"KN" = (
+/obj/structure/window/reinforced/plasma/spawner/west,
+/obj/structure/window/reinforced/plasma/spawner/north,
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/voidcrew/osprey/maintenance/port)
+"KO" = (
+/turf/open/floor/plating,
+/area/shuttle/voidcrew/osprey/maintenance/starboard)
 "KT" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/station/medical/medbay/lobby)
+/area/shuttle/voidcrew/osprey/medbay/lobby)
 "KV" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/stripes/corner{
@@ -3809,7 +3797,7 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "Ld" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/cable,
@@ -3817,7 +3805,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/shuttle/voidcrew/osprey/hallway/starboard)
 "Lh" = (
 /obj/item/storage/backpack,
 /obj/item/clothing/gloves/color/white,
@@ -3825,22 +3813,19 @@
 /obj/machinery/airalarm/directional/south,
 /obj/structure/closet/secure_closet/hop,
 /turf/open/floor/carpet/blue,
-/area/station/command/bridge)
+/area/shuttle/voidcrew/osprey/bridge)
 "Lj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron,
-/area/station/hallway/primary/aft)
-"Lk" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/station/cargo/office)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "Lq" = (
 /obj/machinery/firealarm/directional/east,
 /obj/structure/ore_box,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
-/area/station/cargo/miningoffice)
+/area/shuttle/voidcrew/osprey/cargo/mining_dock)
 "Lt" = (
 /obj/machinery/power/smes/engineering{
 	dir = 1
@@ -3858,7 +3843,7 @@
 	name = "Thruster Blast Door"
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/shuttle/voidcrew/osprey/maintenance/starboard)
 "LB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/item/wrench,
@@ -3866,24 +3851,24 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/engineering/atmos)
+/area/shuttle/voidcrew/osprey/engineering/atmospherics)
 "LO" = (
 /obj/structure/sign/poster/official/random/directional/north,
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
-"LP" = (
+/area/shuttle/voidcrew/osprey/hallway/aft)
+"LT" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark,
+/area/shuttle/voidcrew/osprey/cargo/mining_dock)
+"Ma" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /obj/machinery/door/poddoor/shutters{
 	id = "ospreywindows";
 	name = "Blast Shutters"
 	},
 /turf/open/floor/plating,
-/area/station/science/research)
-"LT" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark,
-/area/station/cargo/miningoffice)
+/area/shuttle/voidcrew/osprey/engineering/atmospherics)
 "Mj" = (
 /obj/machinery/light{
 	dir = 1
@@ -3891,10 +3876,10 @@
 /obj/structure/closet/secure_closet/miner/unlocked,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
-/area/station/cargo/miningoffice)
+/area/shuttle/voidcrew/osprey/cargo/mining_dock)
 "Ml" = (
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/voidcrew/osprey/hallway/central)
 "Mm" = (
 /obj/machinery/cryopod,
 /obj/machinery/computer/cryopod{
@@ -3907,18 +3892,18 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/commons/dorms)
+/area/shuttle/voidcrew/osprey/service/dormitories)
 "Mn" = (
 /obj/machinery/newscaster/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "Mo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/station/science/robotics/lab)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "Mp" = (
 /obj/machinery/door/airlock/command,
 /obj/structure/cable,
@@ -3929,18 +3914,18 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/wood,
-/area/station/command/bridge)
+/area/shuttle/voidcrew/osprey/bridge)
 "Ms" = (
 /obj/structure/table/reinforced,
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron/showroomfloor,
-/area/station/service/cafeteria)
+/area/shuttle/voidcrew/osprey/service/cafeteria)
 "Mw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/plating,
-/area/station/maintenance/port)
+/area/shuttle/voidcrew/osprey/hallway/port)
 "Mx" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/start/station_engineer,
@@ -3950,7 +3935,7 @@
 	dir = 9
 	},
 /turf/open/floor/catwalk_floor/iron_smooth,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "My" = (
 /obj/structure/railing,
 /obj/effect/landmark/start/head_of_personnel,
@@ -3962,7 +3947,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/station/command/bridge)
+/area/shuttle/voidcrew/osprey/bridge)
 "MJ" = (
 /obj/effect/landmark/start/medical_doctor,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -3972,19 +3957,19 @@
 /obj/effect/turf_decal/trimline/dark_blue/warning,
 /obj/effect/turf_decal/siding/thinplating_new/light,
 /turf/open/floor/iron,
-/area/station/medical/medbay/central)
+/area/shuttle/voidcrew/osprey/medbay)
 "MM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/station/service/cafeteria)
+/area/shuttle/voidcrew/osprey/service/cafeteria)
 "MO" = (
 /obj/effect/turf_decal/stripes{
 	dir = 8
 	},
 /turf/open/floor/iron/smooth,
-/area/station/cargo/warehouse)
+/area/shuttle/voidcrew/osprey/cargo/warehouse)
 "MQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3994,7 +3979,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "MY" = (
 /obj/machinery/cryopod,
 /obj/machinery/light/small,
@@ -4002,11 +3987,11 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/commons/dorms)
+/area/shuttle/voidcrew/osprey/service/dormitories)
 "Nb" = (
 /obj/structure/window/reinforced/plasma/spawner/north,
 /turf/open/floor/plating,
-/area/station/maintenance/port)
+/area/shuttle/voidcrew/osprey/maintenance/port)
 "Ng" = (
 /obj/machinery/computer/communications,
 /obj/effect/turf_decal/tile/dark_blue/half{
@@ -4015,14 +4000,20 @@
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 1
 	},
-/area/station/command/bridge)
+/area/shuttle/voidcrew/osprey/bridge)
+"Nn" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/shuttle/voidcrew/osprey/research)
 "Nr" = (
 /obj/structure/table,
 /obj/item/reagent_containers/cup/bucket,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
-/area/station/service/janitor)
+/area/shuttle/voidcrew/osprey/service/janitor)
 "Nx" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Crew Quarters"
@@ -4031,7 +4022,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/commons/dorms)
+/area/shuttle/voidcrew/osprey/service/dormitories)
 "Nz" = (
 /obj/structure/frame/machine,
 /obj/effect/turf_decal/siding/thinplating_new/light{
@@ -4039,21 +4030,32 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark/textured,
-/area/station/science/research)
+/area/shuttle/voidcrew/osprey/research)
 "NA" = (
 /obj/machinery/power/terminal{
 	dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
+"ND" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/voidcrew/osprey/cargo/quartermaster)
+"NL" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	id = "ospreywindows";
+	name = "Blast Shutters"
+	},
+/turf/open/floor/plating,
+/area/shuttle/voidcrew/osprey/medbay)
 "NP" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "ospreycargo"
 	},
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
-/area/station/cargo/office)
+/area/shuttle/voidcrew/osprey/cargo)
 "NU" = (
 /obj/machinery/door/airlock{
 	name = "Custodial Office"
@@ -4066,7 +4068,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/station/service/janitor)
+/area/shuttle/voidcrew/osprey/service/janitor)
 "NV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -4081,14 +4083,25 @@
 	},
 /obj/structure/window/spawner/north,
 /turf/open/floor/iron/showroomfloor,
-/area/station/service/cafeteria)
+/area/shuttle/voidcrew/osprey/service/cafeteria)
+"NX" = (
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "NY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/station/medical/medbay/lobby)
+/area/shuttle/voidcrew/osprey/medbay/lobby)
+"NZ" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/voidcrew/osprey/hallway/aft)
+"Oa" = (
+/obj/structure/sign/warning/vacuum/external,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/voidcrew/osprey/maintenance/port)
 "Oe" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -4101,7 +4114,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/shuttle/voidcrew/osprey/maintenance/starboard)
 "Of" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -4113,15 +4126,15 @@
 	dir = 5
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/service/cafeteria)
+/area/shuttle/voidcrew/osprey/service/cafeteria)
 "Ok" = (
 /obj/structure/cable/layer3,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "Os" = (
 /obj/effect/turf_decal/bot/right,
 /turf/open/floor/iron/dark,
-/area/station/cargo/miningoffice)
+/area/shuttle/voidcrew/osprey/cargo/mining_dock)
 "Ov" = (
 /obj/structure/cable,
 /obj/machinery/light{
@@ -4130,7 +4143,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "Ow" = (
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom{
@@ -4154,11 +4167,11 @@
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 1
 	},
-/area/station/command/bridge)
+/area/shuttle/voidcrew/osprey/bridge)
 "Ox" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "OO" = (
 /obj/structure/sink/directional/east,
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -4171,7 +4184,7 @@
 	},
 /obj/item/clothing/gloves/color/latex,
 /turf/open/floor/iron,
-/area/station/medical/medbay/central)
+/area/shuttle/voidcrew/osprey/medbay)
 "OR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4186,7 +4199,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/service/cafeteria)
+/area/shuttle/voidcrew/osprey/service/cafeteria)
 "OU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -4195,20 +4208,20 @@
 /obj/structure/cable/layer3,
 /obj/effect/turf_decal/stripes,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "OV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/station/cargo/office)
+/area/shuttle/voidcrew/osprey/cargo)
 "Ph" = (
 /obj/structure/table/wood,
 /obj/item/folder,
 /obj/item/pen,
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/carpet,
-/area/station/commons/dorms)
+/area/shuttle/voidcrew/osprey/service/dormitories)
 "Pm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/effect/spawner/random/maintenance,
@@ -4217,15 +4230,7 @@
 	},
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
-"Po" = (
-/obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor/shutters{
-	id = "ospreywindows";
-	name = "Blast Shutters"
-	},
-/turf/open/floor/plating,
-/area/station/service/janitor)
+/area/shuttle/voidcrew/osprey/maintenance/starboard)
 "PC" = (
 /obj/structure/window/reinforced/plasma/spawner/east,
 /obj/structure/window/reinforced/plasma/spawner/north,
@@ -4233,31 +4238,14 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
-"PJ" = (
-/obj/structure/window/reinforced/plasma/spawner/west,
+/area/shuttle/voidcrew/osprey/maintenance/starboard)
+"PL" = (
 /obj/structure/window/reinforced/plasma/spawner/north,
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 1
-	},
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
-"PK" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/station/maintenance/starboard)
-"PN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/maintenance/starboard)
 "PU" = (
 /turf/open/floor/iron/white,
-/area/station/science/research)
+/area/shuttle/voidcrew/osprey/medbay)
 "PW" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp{
@@ -4267,10 +4255,10 @@
 	pixel_x = -10
 	},
 /turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
+/area/shuttle/voidcrew/osprey/engineering/atmospherics)
 "PY" = (
 /turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "Qa" = (
 /obj/machinery/mass_driver{
 	dir = 8;
@@ -4281,7 +4269,12 @@
 /obj/item/trash/can/food/beans,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
-/area/station/service/janitor)
+/area/shuttle/voidcrew/osprey/service/janitor)
+"Qp" = (
+/obj/machinery/power/terminal,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/shuttle/voidcrew/osprey/maintenance/port)
 "Qq" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -4293,7 +4286,7 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
+/area/shuttle/voidcrew/osprey/cargo/warehouse)
 "Qu" = (
 /obj/machinery/computer/atmos_alert{
 	dir = 8
@@ -4303,7 +4296,15 @@
 	},
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
+/area/shuttle/voidcrew/osprey/engineering/atmospherics)
+"Qv" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/shuttle/voidcrew/osprey/maintenance/port)
 "QA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/cable,
@@ -4319,12 +4320,15 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/area/shuttle/voidcrew/osprey/hallway/port)
 "QB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
+"QC" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/voidcrew/osprey/service/janitor)
 "QH" = (
 /obj/machinery/button/massdriver{
 	id = "osprey_disposals";
@@ -4340,7 +4344,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
-/area/station/service/janitor)
+/area/shuttle/voidcrew/osprey/service/janitor)
 "QJ" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -4351,12 +4355,16 @@
 	},
 /obj/structure/fireaxecabinet/directional/west,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/station/engineering/atmos)
+/area/shuttle/voidcrew/osprey/engineering/atmospherics)
 "QL" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
 /turf/open/floor/wood,
-/area/station/service/cafeteria)
+/area/shuttle/voidcrew/osprey/service/cafeteria)
+"QP" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/turf/open/floor/plating,
+/area/shuttle/voidcrew/osprey/bridge)
 "QT" = (
 /obj/machinery/light{
 	dir = 1
@@ -4371,7 +4379,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/medical/medbay/central)
+/area/shuttle/voidcrew/osprey/medbay)
 "QV" = (
 /obj/structure/tank_dispenser/oxygen,
 /obj/structure/sign/poster/official/safety_internals{
@@ -4380,21 +4388,7 @@
 /obj/machinery/firealarm/directional/east,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
-/area/station/hallway/primary/port)
-"Rd" = (
-/obj/machinery/door/airlock/maintenance/external,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/station/hallway/primary/port)
-"Rg" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/science/research)
+/area/shuttle/voidcrew/osprey/hallway/port)
 "Rm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/cable,
@@ -4402,7 +4396,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
-/area/station/hallway/primary/port)
+/area/shuttle/voidcrew/osprey/hallway/port)
+"Rq" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/voidcrew/osprey/cargo/mining_dock)
 "Rv" = (
 /obj/machinery/light{
 	dir = 8
@@ -4414,12 +4411,12 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
+/area/shuttle/voidcrew/osprey/cargo/warehouse)
 "RC" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/smooth,
-/area/station/cargo/warehouse)
+/area/shuttle/voidcrew/osprey/cargo/warehouse)
 "RE" = (
 /obj/machinery/door/airlock{
 	name = "Head"
@@ -4428,19 +4425,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/iron/grimy,
-/area/station/commons/dorms)
-"RG" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/station/science/research)
+/area/shuttle/voidcrew/osprey/service/dormitories)
 "RZ" = (
 /obj/structure/dresser,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/grimy,
-/area/station/commons/dorms)
+/area/shuttle/voidcrew/osprey/service/dormitories)
 "Sb" = (
 /obj/structure/sign/departments/custodian,
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/station/service/janitor)
+/area/shuttle/voidcrew/osprey/service/janitor)
 "Sc" = (
 /obj/structure/closet/crate{
 	name = "food crate"
@@ -4448,18 +4442,18 @@
 /obj/effect/spawner/random/maintenance/three,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/smooth,
-/area/station/cargo/warehouse)
+/area/shuttle/voidcrew/osprey/cargo/warehouse)
 "Sl" = (
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/iron,
-/area/station/service/janitor)
+/area/shuttle/voidcrew/osprey/service/janitor)
 "Sr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/shuttle/voidcrew/osprey/hallway/central)
 "Ss" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4467,13 +4461,16 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/shuttle/voidcrew/osprey/hallway/central)
+"Sw" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/voidcrew/osprey/maintenance/starboard)
 "Sy" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/area/shuttle/voidcrew/osprey/hallway/port)
 "SF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4483,13 +4480,13 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
-/area/station/service/janitor)
+/area/shuttle/voidcrew/osprey/service/janitor)
 "SN" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/airalarm/directional/east,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
-/area/station/hallway/primary/port)
+/area/shuttle/voidcrew/osprey/hallway/port)
 "SO" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -4499,7 +4496,7 @@
 	dir = 1
 	},
 /turf/open/floor/carpet,
-/area/station/commons/dorms)
+/area/shuttle/voidcrew/osprey/service/dormitories)
 "SP" = (
 /obj/machinery/atmospherics/components/tank/air{
 	dir = 8
@@ -4508,7 +4505,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/engineering/atmos)
+/area/shuttle/voidcrew/osprey/engineering/atmospherics)
 "SQ" = (
 /obj/structure/cable,
 /obj/structure/window/reinforced/plasma/spawner,
@@ -4520,7 +4517,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/port)
+/area/shuttle/voidcrew/osprey/maintenance/port)
 "SU" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
@@ -4530,7 +4527,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/plating,
-/area/station/maintenance/port)
+/area/shuttle/voidcrew/osprey/maintenance/port)
+"SV" = (
+/obj/machinery/door/airlock/public/glass,
+/turf/open/floor/iron,
+/area/shuttle/voidcrew/osprey/hallway/starboard)
 "SW" = (
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/sheet/iron/fifty,
@@ -4542,17 +4543,12 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/station/science/robotics/lab)
-"SX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "SZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
-/area/station/service/janitor)
+/area/shuttle/voidcrew/osprey/service/janitor)
 "Td" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -4562,14 +4558,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/service/janitor)
-"Ti" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/station/cargo/office)
+/area/shuttle/voidcrew/osprey/service/janitor)
 "Tl" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave{
@@ -4577,36 +4566,38 @@
 	},
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron/showroomfloor,
-/area/station/service/cafeteria)
+/area/shuttle/voidcrew/osprey/service/cafeteria)
 "Tp" = (
 /obj/item/wrench,
 /turf/open/floor/plating,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "Tt" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/structure/sign/warning/no_smoking/directional/west,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
-"Tu" = (
-/obj/structure/window/reinforced/plasma/spawner/north,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/shuttle/voidcrew/osprey/engineering)
 "Tw" = (
 /obj/machinery/door/airlock/public/glass,
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/shuttle/voidcrew/osprey/hallway/port)
 "TA" = (
 /obj/machinery/atmospherics/components/tank/plasma{
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/station/engineering/atmos)
+/area/shuttle/voidcrew/osprey/engineering/atmospherics)
 "TB" = (
 /obj/effect/turf_decal/bot_white/left,
 /turf/open/floor/iron/dark,
-/area/station/cargo/miningoffice)
+/area/shuttle/voidcrew/osprey/cargo/mining_dock)
+"TF" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/voidcrew/osprey/hallway/aft)
+"TI" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/voidcrew/osprey/hallway/starboard)
 "TJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4618,7 +4609,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "TM" = (
 /obj/structure/chair{
 	dir = 8
@@ -4626,7 +4617,7 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/station/medical/medbay/lobby)
+/area/shuttle/voidcrew/osprey/medbay/lobby)
 "TQ" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 1
@@ -4637,7 +4628,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/station/command/heads_quarters/qm)
+/area/shuttle/voidcrew/osprey/cargo/quartermaster)
 "TT" = (
 /obj/item/trash/can/food,
 /obj/effect/decal/cleanable/dirt,
@@ -4645,7 +4636,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/science/robotics/lab)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "TU" = (
 /obj/structure/toilet{
 	dir = 4
@@ -4657,15 +4648,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/commons/dorms)
-"TV" = (
-/obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor/shutters{
-	id = "ospreywindows";
-	name = "Blast Shutters"
-	},
-/turf/open/floor/plating,
-/area/station/medical/medbay/central)
+/area/shuttle/voidcrew/osprey/service/dormitories)
 "TZ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4674,7 +4657,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/shuttle/voidcrew/osprey/hallway/central)
 "Ub" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4689,11 +4672,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/station/command/bridge)
-"Ui" = (
-/obj/machinery/door/airlock/public/glass,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/area/shuttle/voidcrew/osprey/bridge)
 "Uj" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
@@ -4701,10 +4680,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/station/maintenance/port)
-"Uk" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/station/hallway/primary/central)
+/area/shuttle/voidcrew/osprey/maintenance/starboard)
 "Um" = (
 /obj/structure/sink/kitchen/directional/east,
 /obj/structure/mirror{
@@ -4713,35 +4689,32 @@
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron/showroomfloor,
-/area/station/service/cafeteria)
-"Ur" = (
-/turf/closed/wall/mineral/titanium,
-/area/station/medical/medbay/central)
+/area/shuttle/voidcrew/osprey/service/cafeteria)
 "Uv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
-/area/station/commons/dorms)
+/area/shuttle/voidcrew/osprey/service/dormitories)
 "UC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/station/commons/dorms)
+/area/shuttle/voidcrew/osprey/service/dormitories)
 "UE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/station/cargo/warehouse)
+/area/shuttle/voidcrew/osprey/cargo/warehouse)
 "UQ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "US" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -4751,18 +4724,12 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/shuttle/voidcrew/osprey/hallway/starboard)
 "UT" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron/showroomfloor,
-/area/station/service/cafeteria)
-"UU" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/station/hallway/primary/port)
-"UY" = (
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/shuttle/voidcrew/osprey/service/cafeteria)
 "Va" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
@@ -4770,25 +4737,25 @@
 	},
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/shuttle/voidcrew/osprey/hallway/starboard)
 "Vl" = (
 /obj/machinery/washing_machine,
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
-/area/station/commons/dorms)
+/area/shuttle/voidcrew/osprey/service/dormitories)
 "Vp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/chair/stool/bar,
 /turf/open/floor/wood,
-/area/station/service/cafeteria)
+/area/shuttle/voidcrew/osprey/service/cafeteria)
 "Vr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
-/area/station/medical/medbay/lobby)
+/area/shuttle/voidcrew/osprey/medbay/lobby)
 "Vu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/machinery/light/small{
@@ -4796,30 +4763,43 @@
 	},
 /obj/structure/sign/warning/no_smoking/directional/north,
 /turf/open/floor/plating,
-/area/station/engineering/atmos)
+/area/shuttle/voidcrew/osprey/engineering/atmospherics)
 "Vz" = (
 /obj/machinery/airalarm/directional/south,
 /obj/structure/chair/sofa/right/brown{
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/station/service/cafeteria)
+/area/shuttle/voidcrew/osprey/service/cafeteria)
 "VF" = (
 /obj/structure/chair/stool/bar,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
-/area/station/service/cafeteria)
+/area/shuttle/voidcrew/osprey/service/cafeteria)
+"VG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/shuttle/voidcrew/osprey/hallway/starboard)
+"VJ" = (
+/obj/machinery/power/shuttle_engine/ship/fueled/plasma{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/voidcrew/osprey/maintenance/starboard)
 "VM" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/cargo/miningoffice)
+/area/shuttle/voidcrew/osprey/cargo/mining_dock)
 "VO" = (
 /obj/machinery/light/small,
 /obj/structure/bed,
 /obj/item/bedsheet/hop,
 /obj/structure/curtain/cloth/fancy,
 /turf/open/floor/carpet/blue,
-/area/station/command/bridge)
+/area/shuttle/voidcrew/osprey/bridge)
 "VT" = (
 /obj/structure/disposaloutlet{
 	dir = 1
@@ -4836,7 +4816,7 @@
 	id = "osprey_conveyor"
 	},
 /turf/open/floor/plating,
-/area/station/service/janitor)
+/area/shuttle/voidcrew/osprey/service/janitor)
 "Wg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -4845,21 +4825,18 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "Wh" = (
 /obj/structure/cable,
 /obj/machinery/power/shuttle_engine/ship/electric{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/port)
-"WJ" = (
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/maintenance/starboard)
 "WK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/shuttle/voidcrew/osprey/hallway/starboard)
 "WR" = (
 /obj/machinery/light{
 	dir = 1
@@ -4872,7 +4849,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/robotics/lab)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "WW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2
@@ -4881,18 +4858,18 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "WY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
+/area/shuttle/voidcrew/osprey/engineering/atmospherics)
 "Xb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
-/area/station/cargo/miningoffice)
+/area/shuttle/voidcrew/osprey/cargo/mining_dock)
 "Xd" = (
 /obj/machinery/door/window/right/directional/east{
 	name = "Kitchen"
@@ -4902,7 +4879,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/service/cafeteria)
+/area/shuttle/voidcrew/osprey/service/cafeteria)
 "Xi" = (
 /obj/structure/window/reinforced/plasma/spawner/west,
 /obj/structure/window/reinforced/plasma/spawner/north,
@@ -4910,7 +4887,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/port)
+/area/shuttle/voidcrew/osprey/maintenance/starboard)
 "Xm" = (
 /obj/machinery/medical_kiosk,
 /obj/machinery/light{
@@ -4918,7 +4895,10 @@
 	},
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/wood,
-/area/station/medical/medbay/lobby)
+/area/shuttle/voidcrew/osprey/medbay/lobby)
+"Xo" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/voidcrew/osprey/cargo)
 "Xp" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 1
@@ -4928,7 +4908,7 @@
 /obj/effect/turf_decal/siding/wood/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
-/area/station/command/heads_quarters/qm)
+/area/shuttle/voidcrew/osprey/cargo/quartermaster)
 "XB" = (
 /obj/structure/railing{
 	dir = 8
@@ -4939,13 +4919,13 @@
 	dir = 9
 	},
 /turf/open/floor/wood,
-/area/station/command/bridge)
+/area/shuttle/voidcrew/osprey/bridge)
 "XE" = (
 /obj/structure/reagent_dispensers,
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "XH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/cable,
@@ -4958,7 +4938,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "XL" = (
 /obj/structure/railing{
 	dir = 4
@@ -4971,7 +4951,7 @@
 	dir = 5
 	},
 /turf/open/floor/wood,
-/area/station/command/bridge)
+/area/shuttle/voidcrew/osprey/bridge)
 "XO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/cable,
@@ -4979,11 +4959,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/public/glass,
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/shuttle/voidcrew/osprey/hallway/starboard)
 "XR" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/iron/dark/textured,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "XS" = (
 /obj/structure/closet/secure_closet/captains{
 	icon_state = "cap";
@@ -4994,7 +4974,7 @@
 	pixel_x = 32
 	},
 /turf/open/floor/carpet/royalblue,
-/area/station/command/bridge)
+/area/shuttle/voidcrew/osprey/bridge)
 "XU" = (
 /turf/template_noop,
 /area/template_noop)
@@ -5002,18 +4982,18 @@
 /obj/machinery/suit_storage_unit/engine,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth_large,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "Yd" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/carpet,
-/area/station/commons/dorms)
+/area/shuttle/voidcrew/osprey/service/dormitories)
 "Ym" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/cargo/miningoffice)
+/area/shuttle/voidcrew/osprey/cargo/warehouse)
 "Yn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -5021,7 +5001,7 @@
 /obj/effect/turf_decal/siding/thinplating_new/light,
 /obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/iron,
-/area/station/medical/medbay/central)
+/area/shuttle/voidcrew/osprey/medbay)
 "Yo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -5030,11 +5010,24 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
+/area/shuttle/voidcrew/osprey/engineering/atmospherics)
+"Yp" = (
+/turf/open/floor/iron,
+/area/shuttle/voidcrew/osprey/hallway/port)
+"Yt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/shuttle/voidcrew/osprey/hallway/starboard)
 "Yx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/shuttle/voidcrew/osprey/maintenance/port)
 "YA" = (
 /obj/machinery/computer/monitor{
 	dir = 8
@@ -5042,27 +5035,23 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth_large,
-/area/station/engineering/main)
+/area/shuttle/voidcrew/osprey/engineering)
 "YK" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/port)
+/area/shuttle/voidcrew/osprey/maintenance/port)
 "YS" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/station/science/research)
+/area/shuttle/voidcrew/osprey/research/robotics)
 "YW" = (
 /obj/structure/frame/computer{
 	anchored = 1;
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/station/cargo/warehouse)
-"Za" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
-/turf/open/floor/plating,
-/area/station/maintenance/port)
+/area/shuttle/voidcrew/osprey/cargo/warehouse)
 "Zl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -5070,7 +5059,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
-/area/station/cargo/office)
+/area/shuttle/voidcrew/osprey/cargo)
 "Zs" = (
 /obj/machinery/shower/directional/east,
 /obj/structure/curtain,
@@ -5080,7 +5069,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/commons/dorms)
+/area/shuttle/voidcrew/osprey/service/dormitories)
 "Zt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/cable,
@@ -5093,29 +5082,29 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/area/shuttle/voidcrew/osprey/hallway/port)
 "ZD" = (
 /obj/structure/closet/firecloset/full,
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/carpet,
-/area/station/commons/dorms)
+/area/shuttle/voidcrew/osprey/service/dormitories)
 "ZF" = (
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/station/science/research)
+/area/shuttle/voidcrew/osprey/research)
 "ZK" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "ZN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "ZU" = (
 /obj/structure/cable,
 /obj/structure/extinguisher_cabinet/directional/south,
@@ -5123,12 +5112,12 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/shuttle/voidcrew/osprey/hallway/aft)
 "ZV" = (
 /obj/structure/cable,
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/shuttle/voidcrew/osprey/maintenance/starboard)
 
 (1,1,1) = {"
 XU
@@ -5165,27 +5154,27 @@ XU
 XU
 XU
 XU
-HS
+Ki
 DQ
-cq
+oN
 DQ
-cq
+oN
 DQ
 DQ
-pT
+QC
 bz
-pT
-pT
-Po
-pT
-rM
+QC
+QC
+ze
+QC
+uA
 oA
-rM
-rM
-rM
-rM
-rM
-rM
+lW
+lW
+lW
+lW
+lW
+lW
 XU
 "}
 (2,1,1) = {"
@@ -5222,7 +5211,7 @@ XU
 XU
 XU
 XU
-HS
+Ki
 DQ
 Kh
 qK
@@ -5230,21 +5219,21 @@ NV
 cu
 Um
 Tl
-pT
+QC
 Qa
 VT
 rm
 lc
 ec
-Id
+sH
 Mw
-rM
+lW
 ff
 IM
 Gb
 gr
-Xi
-mp
+KN
+fU
 "}
 (3,1,1) = {"
 XU
@@ -5280,7 +5269,7 @@ XU
 XU
 XU
 XU
-cq
+oN
 Jk
 rj
 QL
@@ -5288,21 +5277,21 @@ dw
 cu
 rv
 dy
-pT
+QC
 QH
 Dw
 cC
 SZ
 Eo
-rM
+uA
 qD
-rM
+lW
 EB
 xw
 tX
 nh
 Nb
-mp
+fU
 "}
 (4,1,1) = {"
 XU
@@ -5338,7 +5327,7 @@ XU
 XU
 XU
 XU
-cq
+oN
 Ep
 sZ
 VF
@@ -5346,21 +5335,21 @@ aJ
 cu
 cu
 Ms
-pT
+QC
 Sl
 JC
 el
 tH
 fi
-rM
-DD
-rM
+uA
+pB
+lW
 SU
 DI
 eb
-Za
-ef
-mp
+Yx
+dZ
+fU
 "}
 (5,1,1) = {"
 XU
@@ -5396,7 +5385,7 @@ XU
 XU
 XU
 XU
-cq
+oN
 jV
 rj
 fR
@@ -5404,21 +5393,21 @@ aJ
 cu
 UT
 jy
-pT
+QC
 Kl
 SF
 Td
 Nr
 zk
-rM
+uA
 bf
-jf
-Uj
-rM
+Oa
+Qv
+lW
 YK
-il
+Qp
 cY
-Wh
+JK
 "}
 (6,1,1) = {"
 XU
@@ -5454,7 +5443,7 @@ XU
 XU
 XU
 XU
-HS
+Ki
 DQ
 Hs
 Vp
@@ -5462,21 +5451,21 @@ Of
 Xd
 FO
 DQ
-pT
-pT
+QC
+QC
 NU
 Sb
-pT
-pT
-pT
+QC
+QC
+uA
 sl
 mR
 Rm
-rM
+lW
 zz
-il
+Qp
 SQ
-Wh
+JK
 "}
 (7,1,1) = {"
 XU
@@ -5526,15 +5515,15 @@ uP
 fS
 gm
 fS
-Rd
+Ig
 Rm
 kW
-yU
-rM
+IN
+lW
 nu
-il
+Qp
 no
-Wh
+JK
 "}
 (8,1,1) = {"
 XU
@@ -5544,14 +5533,14 @@ XU
 XU
 XU
 XU
-hB
-zI
-gb
-zI
-zI
-gb
-zI
-hB
+Bz
+tI
+kN
+tI
+tI
+kN
+tI
+Bz
 XU
 XU
 XU
@@ -5583,15 +5572,15 @@ Zt
 nl
 bs
 Sy
-PY
-UU
+Yp
+uA
 QV
 wP
 SN
-jf
-rM
-rM
-rM
+Oa
+lW
+lW
+lW
 XU
 "}
 (9,1,1) = {"
@@ -5601,16 +5590,16 @@ XU
 XU
 XU
 XU
-hw
-zI
+Bz
+tI
 jN
 tV
 mV
 oO
 pi
 rs
-zI
-uD
+tI
+mf
 XU
 XU
 XU
@@ -5627,26 +5616,26 @@ XU
 XU
 XU
 XU
-bP
-sn
-pO
-pO
+NZ
+gZ
+DQ
+DQ
 sG
 OR
-zQ
-zQ
+KI
+KI
 DQ
-Ui
+Tw
 cS
 xh
 xh
 xh
 xh
 xh
-qf
-UU
-UU
-iF
+ja
+uA
+uA
+id
 XU
 XU
 XU
@@ -5657,18 +5646,18 @@ XU
 XU
 XU
 XU
-hw
-hw
-Dp
-zI
+oX
+oX
+Rq
+tI
 gM
 zs
 jn
 Gn
 CW
 lT
-zI
-RG
+tI
+oQ
 XU
 XU
 XU
@@ -5685,11 +5674,11 @@ XU
 XU
 XU
 XU
-sn
+gZ
 HV
 Hv
 Ox
-WJ
+PY
 aK
 EL
 EL
@@ -5701,7 +5690,7 @@ XE
 Tt
 IZ
 Fu
-qf
+ja
 lU
 XU
 XU
@@ -5712,22 +5701,22 @@ XU
 "}
 (11,1,1) = {"
 XU
-hw
-Dp
-Dp
-hw
+oX
+Rq
+Rq
+oX
 bL
 ej
-zI
+tI
 WR
 mk
 nM
 vm
 cJ
 nK
-zI
-RG
-uD
+tI
+oQ
+mf
 XU
 XU
 XU
@@ -5742,8 +5731,8 @@ XU
 XU
 XU
 XU
-Ur
-pO
+NZ
+TF
 ow
 UQ
 Ox
@@ -5769,47 +5758,47 @@ XU
 XU
 "}
 (12,1,1) = {"
-hw
-Dp
-Dp
-Dp
+oX
+Rq
+Rq
+Rq
 kj
 Cm
-aw
-KO
+FG
+mt
 qO
 HM
 JO
 IB
 pF
 rX
-RG
+tI
 Ky
-RG
-LP
-RG
-LP
-RG
-RG
-Uk
+oQ
 CA
-Uk
-Do
-Do
-TV
-Do
-TV
-Do
-Do
-pO
+oQ
+CA
+oQ
+oQ
+Ml
+vA
+Ml
+tM
+tM
+NL
+tM
+NL
+tM
+tM
+tM
 ZK
 UQ
-qn
-qn
-qn
-qn
-qn
-sB
+BQ
+BQ
+BQ
+BQ
+BQ
+ke
 FE
 Ei
 xh
@@ -5817,7 +5806,7 @@ iH
 IS
 YA
 eM
-qf
+ja
 lU
 XU
 XU
@@ -5830,11 +5819,11 @@ XU
 XU
 XU
 dr
-ap
+kw
 mQ
-aw
+FG
 fE
-KO
+mt
 SW
 KA
 rF
@@ -5852,32 +5841,32 @@ Cf
 Ss
 TZ
 Dg
-Do
+tM
 Er
 OO
 ED
 Fy
 FL
 cK
-pO
+tM
 LO
 Mn
-sB
+ke
 yZ
 hC
 zW
 Lh
-sB
+ke
 IA
 BC
 xh
 dC
 KV
-qf
-qf
-qf
-qf
-qf
+ja
+ja
+ja
+ja
+ja
 XU
 XU
 XU
@@ -5889,7 +5878,7 @@ XU
 XU
 wo
 jh
-aw
+FG
 LT
 zJ
 ui
@@ -5900,7 +5889,7 @@ qT
 kS
 lY
 gc
-Rg
+Nn
 EO
 Ct
 Kd
@@ -5910,22 +5899,22 @@ JB
 rb
 Ac
 tf
-Do
+tM
 bn
 MJ
-UY
+PU
 Dc
 tO
 ab
-pO
-kH
+tM
+NX
 UQ
 td
 Ng
 Is
 AW
 VO
-sB
+ke
 tj
 ym
 xh
@@ -5935,7 +5924,7 @@ ml
 ep
 Tp
 gu
-qf
+ja
 XU
 XU
 XU
@@ -5947,9 +5936,9 @@ XU
 XU
 wo
 jh
-aw
+FG
 Gy
-aw
+FG
 JF
 kE
 Ds
@@ -5958,7 +5947,7 @@ TT
 Cb
 xS
 Gv
-PU
+uL
 na
 uZ
 ZF
@@ -5966,16 +5955,16 @@ yV
 zm
 hq
 vD
-kU
+JR
 vz
-Do
+tM
 QT
 Yn
 Fn
 wv
 nk
 lk
-pO
+tM
 sN
 Wg
 td
@@ -5983,17 +5972,17 @@ we
 My
 BW
 XB
-vp
+QP
 ZN
 vo
-Hp
-FG
+nG
+eQ
 Ok
 tc
 qa
 it
 qa
-qf
+ja
 XU
 XU
 XU
@@ -6008,34 +5997,34 @@ jh
 vN
 vN
 hz
-yG
-yG
-yG
-yG
-yG
-yG
-yG
-RG
-RG
-RG
+tI
+tI
+tI
+tI
+tI
+tI
+tI
+tI
+oQ
+oQ
 qe
 Nz
 fx
-RG
-RG
+oQ
+oQ
 Hq
-kU
+JR
 Ft
 DX
 oa
-Ed
+Hp
 iw
 FA
 Gw
 Bl
-pO
+tM
 sN
-WJ
+PY
 td
 Ow
 JQ
@@ -6044,14 +6033,14 @@ Ub
 Mp
 vT
 wY
-Hp
-FG
+nG
+eQ
 aC
 aB
 qa
 qa
 qa
-qf
+ja
 XU
 XU
 XU
@@ -6063,7 +6052,7 @@ XU
 XU
 wo
 jh
-aw
+FG
 TB
 VM
 Jn
@@ -6076,9 +6065,9 @@ Rv
 vj
 ut
 fq
-zb
-zb
-zb
+BD
+BD
+BD
 AK
 NP
 Sr
@@ -6099,17 +6088,17 @@ li
 dK
 dJ
 XL
-vp
+QP
 QB
 vo
-Hp
-FG
+nG
+eQ
 Ok
 Kt
 qa
 gu
 qa
-qf
+ja
 XU
 XU
 XU
@@ -6121,11 +6110,11 @@ XU
 XU
 wo
 jh
-aw
+FG
 Xb
-Ym
+ue
 Qq
-SX
+Ym
 UE
 qC
 Cd
@@ -6140,7 +6129,7 @@ ES
 fD
 Cn
 pE
-kU
+JR
 yB
 Ir
 Ji
@@ -6157,7 +6146,7 @@ HF
 Is
 tr
 ae
-sB
+ke
 rN
 EW
 xh
@@ -6165,9 +6154,9 @@ jU
 aC
 AM
 sw
-Bs
+yX
 qa
-qf
+ja
 XU
 XU
 XU
@@ -6178,10 +6167,10 @@ XU
 XU
 XU
 dr
-ap
+kw
 Mj
-aw
-aw
+FG
+FG
 iq
 MO
 MO
@@ -6189,43 +6178,43 @@ MO
 MO
 CR
 MO
-ip
+xk
 wj
 mJ
 JS
 oE
-Ti
+Cr
 Zl
 CQ
-Cr
+HH
 gB
 Di
-sf
+sr
 BG
 KT
 Xm
 wi
 TM
 jT
-HD
+cW
 wl
 ZU
-sB
+ke
 uH
 iC
 dI
 XS
-sB
+ke
 JV
 EW
 xh
 ER
 Hh
 cb
-qf
-qf
-qf
-qf
+ja
+ja
+ja
+ja
 XU
 XU
 XU
@@ -6233,47 +6222,47 @@ XU
 XU
 "}
 (20,1,1) = {"
-hw
-Dp
-Dp
-Dp
+oX
+Rq
+Rq
+Rq
 Bq
 Os
-aw
-JU
+FG
+xk
 ps
 Sc
 nO
 oP
 ln
 RC
-Lk
+eO
 rn
-Lk
-BR
-Lk
-BR
-Lk
-Lk
-Uk
-CA
-Uk
-sf
-sf
-aF
-sf
-aF
-sf
-sf
-pO
+Xo
+gq
+Xo
+gq
+Xo
+Xo
+Ml
+vA
+Ml
+sr
+sr
+uK
+sr
+uK
+sr
+sr
+sr
 oI
 gX
-qn
-qn
-qn
-qn
-qn
-sB
+BQ
+BQ
+BQ
+BQ
+BQ
+ke
 sU
 mj
 xh
@@ -6281,7 +6270,7 @@ js
 OU
 fb
 eq
-qf
+ja
 lU
 XU
 XU
@@ -6292,22 +6281,22 @@ XU
 "}
 (21,1,1) = {"
 XU
-hw
-Dp
-Dp
-hw
+oX
+Rq
+Rq
+oX
 dj
 Lq
-wt
+ND
 oR
-wt
-wt
-wt
+ND
+ND
+ND
 ln
 sM
-yG
-Lk
-aX
+eO
+Xo
+aW
 XU
 XU
 XU
@@ -6322,8 +6311,8 @@ XU
 XU
 XU
 XU
-GD
-pO
+NZ
+TF
 cj
 fZ
 eY
@@ -6339,7 +6328,7 @@ gy
 lX
 bN
 NA
-kq
+sv
 lU
 XU
 XU
@@ -6353,18 +6342,18 @@ XU
 XU
 XU
 XU
-hw
-hw
-Dp
-wt
+oX
+oX
+Rq
+ND
 zF
 Xp
 oK
 oW
 qP
 rD
-yG
-Lk
+eO
+Xo
 XU
 XU
 XU
@@ -6381,23 +6370,23 @@ XU
 XU
 XU
 XU
-sn
+gZ
 fs
-WJ
-WJ
-WJ
-JR
-WJ
-WJ
+PY
+PY
+PY
+jw
+PY
+PY
 cr
-WJ
-PN
+PY
+cg
 aG
 HB
 jg
 Aw
 XX
-qf
+ja
 lU
 XU
 XU
@@ -6413,16 +6402,16 @@ XU
 XU
 XU
 XU
-hw
-wt
+oX
+ND
 Fb
 TQ
 KE
-wt
+ND
 YW
 ug
-yG
-aX
+eO
+aW
 XU
 XU
 XU
@@ -6439,26 +6428,26 @@ XU
 XU
 XU
 XU
-bP
-sn
-mE
-mE
+NZ
+gZ
+KL
+KL
 Nx
 AP
-pJ
-pJ
-mE
-Tw
+pI
+pI
+KL
+SV
 XO
 xh
 xh
 xh
 xh
-qf
-qf
-ao
-ao
-nT
+ja
+ja
+TI
+TI
+Sw
 XU
 XU
 XU
@@ -6472,14 +6461,14 @@ XU
 XU
 XU
 XU
-pY
-wt
-wW
-wt
-wt
-ki
-yG
-ja
+yE
+ND
+su
+ND
+ND
+px
+eO
+kd
 XU
 XU
 XU
@@ -6499,27 +6488,27 @@ XU
 XU
 XU
 XU
-mE
+KL
 RZ
 AH
 ta
 SO
 Yd
-If
+lI
 kf
 Ld
 lq
 nn
 bT
-Ml
-ao
+ac
+TI
 AZ
 zL
 Gp
-PK
-PK
-PK
-PK
+lH
+lH
+lH
+lH
 XU
 "}
 (25,1,1) = {"
@@ -6557,28 +6546,28 @@ XU
 XU
 XU
 XU
-mE
+KL
 ru
 zh
 cw
 lh
 Ph
-If
+lI
 WK
 Gf
-cg
-cg
+Yt
+Yt
 Ch
-cg
+Yt
 md
-IN
-qA
+VG
+pa
 gh
-PK
+lH
 ZV
 op
 Lt
-Eu
+Wh
 "}
 (26,1,1) = {"
 XU
@@ -6614,29 +6603,29 @@ XU
 XU
 XU
 XU
-If
-mE
+lI
+KL
 Uv
 kl
 nS
 fY
 ob
-If
-qq
-qq
+pk
+yx
+yx
 bQ
-qq
-qq
-qq
-qq
+yx
+yx
+yx
+TI
 Hd
 mI
 nI
-PK
+lH
 cc
 oy
 bD
-Eu
+Wh
 "}
 (27,1,1) = {"
 XU
@@ -6672,29 +6661,29 @@ XU
 XU
 XU
 XU
-te
+dd
 jC
 hM
 aE
-mE
-If
-If
-mE
+KL
+lI
+lI
+yx
 gU
 ka
 CI
 QJ
 tW
 lf
-PK
+TI
 Dz
 gF
-dm
-PK
+Uj
+lH
 Ck
 oy
 bD
-Eu
+Wh
 "}
 (28,1,1) = {"
 XU
@@ -6730,29 +6719,29 @@ XU
 XU
 XU
 XU
-te
+dd
 xi
 hM
 AH
-mE
+KL
 TU
 Zs
-If
+pk
 jP
 pC
 WY
 Yo
 oL
 HZ
-PK
-kp
-PK
+TI
+DD
+lH
 jE
 Oe
 lO
-Yx
-PJ
-fU
+EE
+Xi
+VJ
 "}
 (29,1,1) = {"
 XU
@@ -6788,29 +6777,29 @@ XU
 XU
 XU
 XU
-te
+dd
 ZD
 ww
 ww
 RE
 UC
 lg
-If
+pk
 Vu
 DG
 Ix
 BM
 LB
 DP
-PK
+TI
 Va
-sH
+pV
 uu
 DC
 tF
-vv
-Tu
-fU
+KO
+PL
+VJ
 "}
 (30,1,1) = {"
 XU
@@ -6846,29 +6835,29 @@ XU
 XU
 XU
 XU
-If
-mE
+lI
+KL
 Mm
 MY
-mE
+KL
 qy
 Vl
-If
+pk
 TA
 vS
 PW
 Qu
 SP
 iS
-PK
+TI
 kJ
-sH
+pV
 eP
 He
 Pm
-Yx
+EE
 PC
-fU
+VJ
 "}
 (31,1,1) = {"
 XU
@@ -6905,26 +6894,26 @@ XU
 XU
 XU
 XU
-If
-mE
-te
-mE
-te
-mE
-mE
-qq
-Jt
-qq
-qq
-Jt
-qq
-PK
+lI
+KL
+dd
+KL
+dd
+KL
+yx
+yx
+Ma
+yx
+yx
+Ma
+yx
+TI
 US
-PK
-PK
-PK
-PK
-PK
-PK
+lH
+lH
+lH
+lH
+lH
+lH
 XU
 "}

--- a/_maps/voidcrew/ship_osprey.dmm
+++ b/_maps/voidcrew/ship_osprey.dmm
@@ -149,7 +149,6 @@
 	name = "Disposals Blast Door"
 	},
 /obj/structure/fans/tiny,
-/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/station/service/janitor)
 "bD" = (
@@ -211,6 +210,10 @@
 	dir = 4
 	},
 /area/station/engineering/atmos)
+"bT" = (
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "cb" = (
 /obj/structure/sign/warning/electric_shock,
 /turf/closed/wall/mineral/titanium,
@@ -231,7 +234,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "cj" = (
@@ -248,15 +253,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "cm" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/effect/turf_decal/siding/thinplating_new/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes{
+/obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/turf/open/floor/circuit/off,
-/area/station/science/robotics/lab)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/cargo/office)
 "cq" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /obj/machinery/door/poddoor/shutters{
@@ -290,6 +294,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/service/janitor)
+"cJ" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new,
+/turf/open/floor/circuit/off,
+/area/station/science/robotics/lab)
 "cK" = (
 /obj/structure/closet/secure_closet{
 	icon_state = "med";
@@ -322,13 +333,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/medical/medbay/central)
-"cP" = (
-/obj/structure/sign/nanotrasen{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
 "cS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/cable,
@@ -384,16 +388,29 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
-"dn" = (
-/obj/structure/bed/pod,
-/obj/item/bedsheet/qm,
-/obj/structure/curtain/cloth,
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+"dr" = (
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/closet/emcloset/anchored,
+/turf/open/floor/plating/airless,
+/area/station/cargo/miningoffice)
+"dw" = (
+/obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/turf/open/floor/carpet/orange,
-/area/station/command/heads_quarters/qm)
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/griddle,
+/obj/structure/window/spawner/north,
+/obj/structure/window/spawner/east,
+/turf/open/floor/iron/showroomfloor,
+/area/station/service/cafeteria)
 "dy" = (
 /obj/machinery/light,
 /obj/item/radio/intercom/directional/south,
@@ -401,6 +418,10 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/cafeteria)
+"dC" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/station/engineering/main)
 "dI" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
@@ -472,8 +493,8 @@
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "eq" = (
-/obj/machinery/suit_storage_unit/engine,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/main)
 "eB" = (
@@ -483,14 +504,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/medical/medbay/lobby)
-"eH" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/effect/turf_decal/siding/thinplating_new/dark{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/circuit/off,
-/area/station/science/robotics/lab)
 "eM" = (
 /obj/machinery/computer/atmos_alert{
 	dir = 8
@@ -543,16 +556,24 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/station/cargo/office)
-"fx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+"fs" = (
+/obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/neutral{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/area/station/hallway/primary/aft)
+"fx" = (
+/obj/structure/frame/machine,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 6
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark/textured,
+/area/station/science/research)
 "fD" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/start/cargo_technician,
@@ -564,13 +585,11 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "fI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
-/area/station/hallway/primary/port)
+/area/station/cargo/warehouse)
 "fL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -578,10 +597,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"fO" = (
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
 "fR" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=bridge";
@@ -592,11 +607,15 @@
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "fS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/cargo/warehouse)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "fU" = (
 /obj/machinery/power/shuttle_engine/ship/fueled/plasma{
 	dir = 1
@@ -617,15 +636,17 @@
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "fZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/station/hallway/primary/aft)
 "gb" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /obj/machinery/door/poddoor/shutters{
@@ -694,24 +715,18 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "gD" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 2
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/cargo/office)
+/turf/open/floor/catwalk_floor/iron,
+/area/station/hallway/primary/aft)
 "gF" = (
 /obj/structure/sign/warning/vacuum/external,
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/station/maintenance/starboard)
-"gI" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
 "gM" = (
 /obj/item/wallframe/camera,
 /obj/item/wallframe/camera,
@@ -749,10 +764,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"gY" = (
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "hk" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -852,17 +863,10 @@
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "it" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/thinplating_new{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating_new/light{
-	dir = 1
-	},
-/turf/open/floor/circuit/off,
-/area/station/science/robotics/lab)
+/obj/item/stack/pipe_cleaner_coil/cut/yellow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/engineering/main)
 "iw" = (
 /obj/item/paper_bin{
 	pixel_x = 6
@@ -944,9 +948,6 @@
 /obj/machinery/atmospherics/components/tank/air{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes{
-	dir = 1
-	},
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "ja" = (
@@ -973,10 +974,16 @@
 /turf/open/floor/plating,
 /area/station/cargo/miningoffice)
 "jn" = (
-/obj/structure/chair/office,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/dark/diagonal_centre,
-/turf/open/floor/iron/white/diagonal,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 1
+	},
+/turf/open/floor/circuit/off,
 /area/station/science/robotics/lab)
 "js" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -1047,7 +1054,6 @@
 /turf/open/floor/wood,
 /area/station/medical/medbay/lobby)
 "jU" = (
-/obj/effect/decal/cleanable/oil,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
 "jV" = (
@@ -1090,12 +1096,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/commons/dorms)
-"km" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/catwalk_floor/iron,
-/area/station/hallway/primary/aft)
 "kp" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
 	dir = 4
@@ -1120,6 +1120,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
+"kH" = (
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "kJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
@@ -1137,6 +1141,11 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"kS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor/iron_white,
+/area/station/science/robotics/lab)
 "kU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1161,13 +1170,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/service/janitor)
-"le" = (
-/obj/machinery/vending/wardrobe/cargo_wardrobe,
-/obj/effect/turf_decal/siding/thinplating_new{
-	dir = 8
-	},
-/turf/open/floor/iron/smooth,
-/area/station/cargo/office)
 "lf" = (
 /obj/machinery/suit_storage_unit/atmos,
 /obj/machinery/airalarm/directional/south,
@@ -1202,39 +1204,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "ln" = (
-/obj/item/food/canned/beans{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/food/canned/beans{
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/obj/item/food/canned/beans{
-	pixel_x = -2
-	},
-/obj/item/reagent_containers/cup/glass/waterbottle/large{
-	pixel_x = 5
-	},
-/obj/item/reagent_containers/cup/glass/waterbottle/large{
-	pixel_x = 1;
-	pixel_y = -3
-	},
-/obj/item/reagent_containers/cup/glass/waterbottle/large{
-	pixel_x = 8;
-	pixel_y = -3
-	},
-/obj/structure/closet/crate{
-	name = "food crate"
-	},
-/obj/item/storage/cans/sixbeer,
-/obj/item/food/rationpack,
-/obj/item/food/rationpack,
-/obj/item/food/rationpack,
-/obj/item/food/rationpack,
-/obj/item/food/rationpack,
-/obj/item/food/rationpack,
-/obj/effect/turf_decal/bot,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/smooth,
 /area/station/cargo/warehouse)
 "lq" = (
@@ -1247,6 +1219,18 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"lv" = (
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/cargo/warehouse)
 "lO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/structure/cable,
@@ -1343,11 +1327,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port)
-"mr" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/cargo/warehouse)
 "mv" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay"
@@ -1385,24 +1364,6 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/iron,
 /area/station/cargo/office)
-"mL" = (
-/obj/item/stack/pipe_cleaner_coil/cut/yellow,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/engineering/main)
-"mO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
 "mQ" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/light{
@@ -1495,12 +1456,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "nI" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/thinplating_new,
-/turf/open/floor/circuit/off,
-/area/station/science/robotics/lab)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/hallway/primary/starboard)
 "nK" = (
 /obj/item/bodypart/chest/robot,
 /obj/item/bodypart/head/robot,
@@ -1569,14 +1530,8 @@
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "og" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/purple/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/science/robotics/lab)
+/turf/open/floor/catwalk_floor/iron,
+/area/station/hallway/primary/aft)
 "ok" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1729,17 +1684,41 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "ps" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 2
+/obj/item/food/canned/beans{
+	pixel_x = -5;
+	pixel_y = 3
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/item/food/canned/beans{
+	pixel_x = 2;
+	pixel_y = 3
 	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/obj/item/food/canned/beans{
+	pixel_x = -2
+	},
+/obj/item/reagent_containers/cup/glass/waterbottle/large{
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/cup/glass/waterbottle/large{
+	pixel_x = 1;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/cup/glass/waterbottle/large{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/obj/structure/closet/crate{
+	name = "food crate"
+	},
+/obj/item/storage/cans/sixbeer,
+/obj/item/food/rationpack,
+/obj/item/food/rationpack,
+/obj/item/food/rationpack,
+/obj/item/food/rationpack,
+/obj/item/food/rationpack,
+/obj/item/food/rationpack,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/smooth,
+/area/station/cargo/warehouse)
 "pC" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
@@ -1748,11 +1727,19 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "pE" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"pF" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/circuit/off,
+/area/station/science/robotics/lab)
 "pJ" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
@@ -1772,6 +1759,9 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
+"pY" = (
+/turf/closed/wall/mineral/titanium,
+/area/station/command/heads_quarters/qm)
 "qa" = (
 /turf/open/floor/plating,
 /area/station/engineering/main)
@@ -1787,11 +1777,16 @@
 /turf/open/floor/circuit/off,
 /area/station/science/robotics/lab)
 "qe" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/smooth,
-/area/station/cargo/warehouse)
+/obj/machinery/autolathe,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 5
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark/textured,
+/area/station/science/research)
 "qf" = (
 /turf/closed/wall/mineral/titanium,
 /area/station/engineering/main)
@@ -1819,13 +1814,6 @@
 "qq" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/station/engineering/atmos)
-"qv" = (
-/obj/structure/frame/computer{
-	anchored = 1;
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/station/cargo/warehouse)
 "qy" = (
 /obj/structure/sink/directional/south,
 /obj/structure/mirror{
@@ -1888,6 +1876,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/engineering/main)
+"rb" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "rh" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1908,6 +1902,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/service/janitor)
+"rn" = (
+/obj/machinery/vending/wardrobe/cargo_wardrobe,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
+/area/station/cargo/office)
 "rq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1967,6 +1968,13 @@
 "rM" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/station/maintenance/port)
+"rN" = (
+/obj/structure/sign/nanotrasen{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "rW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2052,14 +2060,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "sZ" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/science/robotics/lab)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/wood,
+/area/station/service/cafeteria)
 "ta" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2073,6 +2076,7 @@
 /obj/effect/turf_decal/stripes{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "td" = (
@@ -2135,11 +2139,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "tV" = (
-/obj/effect/turf_decal/stripes{
-	dir = 8
-	},
-/turf/open/floor/iron/smooth,
-/area/station/cargo/warehouse)
+/obj/structure/table_frame,
+/obj/effect/turf_decal/tile/red/diagonal_centre,
+/turf/open/floor/iron/white/diagonal,
+/area/station/science/robotics/lab)
 "tW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
 /obj/effect/turf_decal/stripes{
@@ -2154,6 +2157,16 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"uf" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "ug" = (
 /obj/item/radio/intercom/directional/east,
 /obj/machinery/computer/cargo/express{
@@ -2179,10 +2192,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "up" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "ut" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -2323,11 +2337,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"vI" = (
-/obj/structure/chair/stool/bar,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood,
-/area/station/service/cafeteria)
 "vN" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -2386,8 +2395,10 @@
 	},
 /area/station/command/bridge)
 "wi" = (
-/obj/structure/chair/sofa/bench/left{
-	dir = 8
+/obj/structure/aquarium/prefilled,
+/obj/item/fish_feed{
+	pixel_y = -9;
+	pixel_x = 8
 	},
 /turf/open/floor/wood,
 /area/station/medical/medbay/lobby)
@@ -2409,32 +2420,23 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "wo" = (
-/turf/open/floor/iron,
-/area/station/cargo/office)
-"wt" = (
-/obj/machinery/light{
+/obj/effect/turf_decal/stripes{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/turf/open/floor/plating/airless,
+/area/station/cargo/miningoffice)
+"wt" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/station/command/heads_quarters/qm)
 "wv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "ww" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/cargo/miningoffice)
-"wy" = (
-/obj/structure/frame/machine,
-/obj/effect/turf_decal/siding/thinplating_new/light{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark/textured,
-/area/station/science/research)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/grimy,
+/area/station/commons/dorms)
 "wP" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -2446,14 +2448,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/hallway/primary/port)
-"wR" = (
-/obj/machinery/airalarm/directional/west,
-/obj/machinery/vending/wardrobe/science_wardrobe,
-/obj/effect/turf_decal/siding/thinplating_new/light{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/research)
 "wV" = (
 /obj/structure/cable,
 /obj/machinery/light{
@@ -2466,11 +2460,13 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "wW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/station/science/research)
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	id = "ospreywindows";
+	name = "Blast Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/command/heads_quarters/qm)
 "wY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/cable,
@@ -2499,20 +2495,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/cargo/warehouse)
-"xz" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/thinplating_new,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/circuit/off,
-/area/station/science/robotics/lab)
-"xL" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/wood,
-/area/station/service/cafeteria)
 "xM" = (
 /obj/structure/cable,
 /obj/machinery/navbeacon{
@@ -2521,6 +2505,15 @@
 	},
 /turf/open/floor/wood,
 /area/station/medical/medbay/lobby)
+"xS" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/science/robotics/lab)
 "xV" = (
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/wood,
@@ -2532,6 +2525,19 @@
 	},
 /turf/open/floor/wood,
 /area/station/medical/medbay/lobby)
+"ym" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "yB" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -2542,18 +2548,6 @@
 "yG" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/station/cargo/warehouse)
-"yO" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
 "yU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/cable,
@@ -2580,8 +2574,8 @@
 /turf/open/floor/iron/dark/smooth_corner,
 /area/station/command/bridge)
 "zb" = (
-/turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/turf/open/floor/iron,
+/area/station/cargo/office)
 "zh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2613,11 +2607,21 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"zs" = (
+/obj/structure/chair/office,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/dark/diagonal_centre,
+/turf/open/floor/iron/white/diagonal,
+/area/station/science/robotics/lab)
 "zv" = (
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable,
-/turf/open/floor/iron/smooth_large,
-/area/station/engineering/main)
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/cargo/warehouse)
 "zz" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 32
@@ -2663,15 +2667,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/carpet/blue,
 /area/station/command/bridge)
-"Aa" = (
-/obj/effect/turf_decal/trimline/brown/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
 "Ac" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2862,8 +2857,9 @@
 	},
 /area/station/command/bridge)
 "Cb" = (
-/obj/item/trash/can/food,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 4
 	},
@@ -2871,12 +2867,9 @@
 /area/station/science/robotics/lab)
 "Cd" = (
 /obj/structure/cable,
-/obj/structure/frame/machine,
-/obj/effect/turf_decal/siding/thinplating_new/light{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/science/research)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/cargo/warehouse)
 "Cf" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -2935,6 +2928,30 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"Ct" = (
+/obj/structure/cable,
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/obj/item/pen,
+/obj/item/storage/box/gloves{
+	pixel_x = -6;
+	pixel_y = 13
+	},
+/obj/item/storage/box/rndboards{
+	desc = "A box containing boards for research equipment.";
+	name = "research equipment box";
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 9
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/science/research)
 "CA" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /obj/machinery/door/poddoor/shutters{
@@ -2968,11 +2985,14 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "CR" = (
-/obj/machinery/atmospherics/components/tank/plasma{
+/obj/effect/turf_decal/stripes{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/smooth,
+/area/station/cargo/warehouse)
 "CW" = (
 /obj/item/trash/cheesie,
 /obj/effect/turf_decal/tile/red/opposingcorners,
@@ -3007,11 +3027,14 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/station/cargo/miningoffice)
 "Ds" = (
-/obj/machinery/atmospherics/components/tank/air{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/science/robotics/lab)
 "Dw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -3062,17 +3085,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port)
-"DM" = (
-/obj/machinery/autolathe,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating_new/light{
-	dir = 5
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark/textured,
-/area/station/science/research)
 "DP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/light/small,
@@ -3198,16 +3210,28 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
-"Fb" = (
-/obj/effect/turf_decal/siding/yellow{
-	dir = 1
-	},
-/obj/structure/chair/office/light,
-/obj/effect/landmark/start/quartermaster,
-/obj/effect/turf_decal/siding/wood/corner{
+"EW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
+"Fb" = (
+/obj/structure/bed/pod,
+/obj/item/bedsheet/qm,
+/obj/structure/curtain/cloth,
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/carpet/orange,
 /area/station/command/heads_quarters/qm)
 "Fn" = (
 /obj/structure/chair/office/light{
@@ -3281,7 +3305,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "FG" = (
-/turf/open/floor/iron/dark/textured,
+/turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "FL" = (
 /obj/structure/sign/warning/no_smoking/directional/west,
@@ -3374,7 +3398,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "Gy" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/bot_white/right,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "GD" = (
@@ -3450,14 +3474,20 @@
 	dir = 1
 	},
 /area/station/command/bridge)
+"HM" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/circuit/off,
+/area/station/science/robotics/lab)
 "HS" = (
 /turf/closed/wall/mineral/titanium,
 /area/station/service/cafeteria)
 "HV" = (
 /obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "HZ" = (
@@ -3479,12 +3509,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/medical/medbay/lobby)
-"Iq" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
 "Ir" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/public/glass{
@@ -3509,6 +3533,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"IA" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "IB" = (
 /obj/structure/table,
 /obj/item/circuitboard/aicore,
@@ -3527,18 +3560,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/starboard)
-"IP" = (
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/structure/rack,
-/obj/effect/turf_decal/stripes{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/lab)
 "IS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -3634,14 +3655,6 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
-"JG" = (
-/obj/structure/aquarium/prefilled,
-/obj/item/fish_feed{
-	pixel_y = -9;
-	pixel_x = 8
-	},
-/turf/open/floor/wood,
-/area/station/medical/medbay/lobby)
 "JO" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -3703,25 +3716,9 @@
 /area/station/hallway/primary/aft)
 "Kd" = (
 /obj/structure/cable,
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = 7;
-	pixel_y = 7
-	},
-/obj/item/pen,
-/obj/item/storage/box/gloves{
-	pixel_x = -6;
-	pixel_y = 13
-	},
-/obj/item/storage/box/rndboards{
-	desc = "A box containing boards for research equipment.";
-	name = "research equipment box";
-	pixel_x = -6;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/tile/purple,
+/obj/structure/frame/machine,
 /obj/effect/turf_decal/siding/thinplating_new/light{
-	dir = 9
+	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/science/research)
@@ -3759,14 +3756,28 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "Kt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/grimy,
-/area/station/commons/dorms)
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/engineering/main)
 "Ky" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/catwalk_floor/iron_white,
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/vending/wardrobe/science_wardrobe,
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/research)
+"KA" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/turf/open/floor/circuit/off,
 /area/station/science/robotics/lab)
 "KE" = (
 /obj/structure/table,
@@ -3785,6 +3796,12 @@
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
+"KT" = (
+/obj/structure/chair/sofa/bench/left{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/station/medical/medbay/lobby)
 "KV" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/stripes/corner{
@@ -3793,6 +3810,14 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
+"Ld" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "Lh" = (
 /obj/item/storage/backpack,
 /obj/item/clothing/gloves/color/white,
@@ -3801,23 +3826,19 @@
 /obj/structure/closet/secure_closet/hop,
 /turf/open/floor/carpet/blue,
 /area/station/command/bridge)
+"Lj" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor/iron,
+/area/station/hallway/primary/aft)
 "Lk" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/station/cargo/office)
-"Ll" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "Lq" = (
 /obj/machinery/firealarm/directional/east,
 /obj/structure/ore_box,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/iron/dark,
-/area/station/cargo/miningoffice)
-"Lr" = (
-/obj/effect/turf_decal/bot_white/right,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "Lt" = (
@@ -3838,11 +3859,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
-"Ly" = (
-/obj/structure/table_frame,
-/obj/effect/turf_decal/tile/red/diagonal_centre,
-/turf/open/floor/iron/white/diagonal,
-/area/station/science/robotics/lab)
 "LB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/item/wrench,
@@ -3864,6 +3880,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/science/research)
+"LT" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningoffice)
 "Mj" = (
 /obj/machinery/light{
 	dir = 1
@@ -3895,6 +3915,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"Mo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/science/robotics/lab)
 "Mp" = (
 /obj/machinery/door/airlock/command,
 /obj/structure/cable,
@@ -3949,17 +3973,6 @@
 /obj/effect/turf_decal/siding/thinplating_new/light,
 /turf/open/floor/iron,
 /area/station/medical/medbay/central)
-"ML" = (
-/obj/structure/frame/machine,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/thinplating_new/light{
-	dir = 6
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark/textured,
-/area/station/science/research)
 "MM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -3967,6 +3980,12 @@
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "MO" = (
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
+/area/station/cargo/warehouse)
+"MQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3976,10 +3995,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"MQ" = (
-/obj/structure/cable/layer3,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/engineering/main)
 "MY" = (
 /obj/machinery/cryopod,
 /obj/machinery/light/small,
@@ -4017,6 +4032,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"Nz" = (
+/obj/structure/frame/machine,
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark/textured,
+/area/station/science/research)
 "NA" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -4091,6 +4114,10 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/cafeteria)
+"Ok" = (
+/obj/structure/cable/layer3,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/engineering/main)
 "Os" = (
 /obj/effect/turf_decal/bot/right,
 /turf/open/floor/iron/dark,
@@ -4145,11 +4172,6 @@
 /obj/item/clothing/gloves/color/latex,
 /turf/open/floor/iron,
 /area/station/medical/medbay/central)
-"OP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
 "OR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4212,14 +4234,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
-"PF" = (
-/obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor/shutters{
-	id = "ospreywindows";
-	name = "Blast Shutters"
-	},
-/turf/open/floor/plating,
-/area/station/command/heads_quarters/qm)
 "PJ" = (
 /obj/structure/window/reinforced/plasma/spawner/west,
 /obj/structure/window/reinforced/plasma/spawner/north,
@@ -4241,13 +4255,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"PS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/hallway/primary/starboard)
 "PU" = (
 /turf/open/floor/iron/white,
 /area/station/science/research)
@@ -4275,15 +4282,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/service/janitor)
-"Qn" = (
-/obj/effect/turf_decal/stripes{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/smooth,
-/area/station/cargo/warehouse)
 "Qq" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -4296,9 +4294,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron/dark,
 /area/station/cargo/warehouse)
-"Qr" = (
-/turf/closed/wall/mineral/titanium,
-/area/station/command/heads_quarters/qm)
 "Qu" = (
 /obj/machinery/computer/atmos_alert{
 	dir = 8
@@ -4357,15 +4352,11 @@
 /obj/structure/fireaxecabinet/directional/west,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/atmos)
-"QS" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/purple/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/science/robotics/lab)
+"QL" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
+/turf/open/floor/wood,
+/area/station/service/cafeteria)
 "QT" = (
 /obj/machinery/light{
 	dir = 1
@@ -4405,11 +4396,13 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "Rm" = (
-/obj/effect/turf_decal/stripes{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/station/cargo/miningoffice)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark,
+/area/station/hallway/primary/port)
 "Rv" = (
 /obj/machinery/light{
 	dir = 8
@@ -4456,18 +4449,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/smooth,
 /area/station/cargo/warehouse)
-"Sh" = (
-/obj/effect/turf_decal/trimline/brown/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
 "Sl" = (
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/iron,
@@ -4487,6 +4468,12 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"Sy" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "SF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4514,8 +4501,14 @@
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "SP" = (
-/turf/open/floor/catwalk_floor/iron,
-/area/station/hallway/primary/aft)
+/obj/machinery/atmospherics/components/tank/air{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "SQ" = (
 /obj/structure/cable,
 /obj/structure/window/reinforced/plasma/spawner,
@@ -4528,10 +4521,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port)
-"ST" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/science/robotics/lab)
 "SU" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
@@ -4542,6 +4531,23 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"SW" = (
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/structure/rack,
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
+"SX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/cargo/warehouse)
 "SZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -4557,19 +4563,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/service/janitor)
-"Tg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/machinery/griddle,
-/obj/structure/window/spawner/north,
-/obj/structure/window/spawner/east,
-/turf/open/floor/iron/showroomfloor,
-/area/station/service/cafeteria)
 "Ti" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4605,15 +4598,27 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "TA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
-/area/station/medical/medbay/lobby)
+/obj/machinery/atmospherics/components/tank/plasma{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "TB" = (
 /obj/effect/turf_decal/bot_white/left,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
+"TJ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "TM" = (
 /obj/structure/chair{
 	dir = 8
@@ -4622,6 +4627,25 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/medical/medbay/lobby)
+"TQ" = (
+/obj/effect/turf_decal/siding/yellow{
+	dir = 1
+	},
+/obj/structure/chair/office/light,
+/obj/effect/landmark/start/quartermaster,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/qm)
+"TT" = (
+/obj/item/trash/can/food,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/science/robotics/lab)
 "TU" = (
 /obj/structure/toilet{
 	dir = 4
@@ -4693,13 +4717,6 @@
 "Ur" = (
 /turf/closed/wall/mineral/titanium,
 /area/station/medical/medbay/central)
-"Uu" = (
-/obj/effect/turf_decal/stripes{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/engineering/main)
 "Uv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4719,10 +4736,12 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/cargo/warehouse)
-"UK" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/engineering/main)
+"UQ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "US" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -4765,14 +4784,11 @@
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "Vr" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/turf/open/floor/catwalk_floor/iron,
-/area/station/hallway/primary/aft)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood,
+/area/station/medical/medbay/lobby)
 "Vu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/machinery/light/small{
@@ -4789,8 +4805,8 @@
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "VF" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp,
+/obj/structure/chair/stool/bar,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "VM" = (
@@ -4965,8 +4981,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "XR" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/station/command/heads_quarters/qm)
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/iron/dark/textured,
+/area/station/engineering/main)
 "XS" = (
 /obj/structure/closet/secure_closet/captains{
 	icon_state = "cap";
@@ -4981,6 +4998,11 @@
 "XU" = (
 /turf/template_noop,
 /area/template_noop)
+"XX" = (
+/obj/machinery/suit_storage_unit/engine,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth_large,
+/area/station/engineering/main)
 "Yd" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -4988,18 +5010,10 @@
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "Ym" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningoffice)
 "Yn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -5029,16 +5043,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/main)
-"YH" = (
-/obj/effect/turf_decal/stripes{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/closet/emcloset/anchored,
-/turf/open/floor/plating/airless,
-/area/station/cargo/miningoffice)
 "YK" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -5048,6 +5052,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/science/research)
+"YW" = (
+/obj/structure/frame/computer{
+	anchored = 1;
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/station/cargo/warehouse)
 "Za" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/plating,
@@ -5095,9 +5106,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "ZN" = (
@@ -5120,16 +5129,6 @@
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
-"ZY" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
 
 (1,1,1) = {"
 XU
@@ -5284,8 +5283,8 @@ XU
 cq
 Jk
 rj
-VF
-Tg
+QL
+dw
 cu
 rv
 dy
@@ -5341,8 +5340,8 @@ XU
 XU
 cq
 Ep
-xL
-vI
+sZ
+VF
 aJ
 cu
 cu
@@ -5472,7 +5471,7 @@ pT
 pT
 sl
 mR
-fI
+Rm
 rM
 zz
 il
@@ -5524,11 +5523,11 @@ DQ
 iO
 QA
 uP
-fx
+fS
 gm
-fx
+fS
 Rd
-fI
+Rm
 kW
 yU
 rM
@@ -5583,7 +5582,7 @@ ox
 Zt
 nl
 bs
-Ll
+Sy
 PY
 UU
 QV
@@ -5605,7 +5604,7 @@ XU
 hw
 zI
 jN
-Ly
+tV
 mV
 oO
 pi
@@ -5663,8 +5662,8 @@ hw
 Dp
 zI
 gM
+zs
 jn
-it
 Gn
 CW
 lT
@@ -5687,7 +5686,7 @@ XU
 XU
 XU
 sn
-up
+HV
 Hv
 Ox
 WJ
@@ -5724,7 +5723,7 @@ WR
 mk
 nM
 vm
-nI
+cJ
 nK
 zI
 RG
@@ -5746,12 +5745,12 @@ XU
 Ur
 pO
 ow
-gI
+UQ
 Ox
-SP
+og
 Ov
 HE
-km
+Lj
 Ev
 hk
 XH
@@ -5779,13 +5778,13 @@ Cm
 aw
 KO
 qO
-eH
+HM
 JO
 IB
-xz
+pF
 rX
 RG
-wR
+Ky
 RG
 LP
 RG
@@ -5803,8 +5802,8 @@ TV
 Do
 Do
 pO
-wt
-gI
+ZK
+UQ
 qn
 qn
 qn
@@ -5830,22 +5829,22 @@ XU
 (13,1,1) = {"
 XU
 XU
-YH
+dr
 ap
 mQ
 aw
 fE
 KO
-IP
-cm
+SW
+KA
 rF
 Av
 qc
 qg
 YS
-wW
+up
 uE
-wW
+up
 wV
 fL
 un
@@ -5869,10 +5868,10 @@ hC
 zW
 Lh
 sB
-ZK
+IA
 BC
 xh
-UK
+dC
 KV
 qf
 qf
@@ -5888,27 +5887,27 @@ XU
 (14,1,1) = {"
 XU
 XU
-Rm
+wo
 jh
 aw
-Gy
+LT
 zJ
 ui
-ST
+Mo
 qT
 Am
 qT
-Ky
+kS
 lY
 gc
 Rg
 EO
+Ct
 Kd
-Cd
 az
 Ax
 JB
-pE
+rb
 Ac
 tf
 Do
@@ -5919,8 +5918,8 @@ Dc
 tO
 ab
 pO
-fO
-gI
+kH
+UQ
 td
 Ng
 Is
@@ -5928,9 +5927,9 @@ AW
 VO
 sB
 tj
-mO
+ym
 xh
-jU
+XR
 aC
 ml
 ep
@@ -5946,18 +5945,18 @@ XU
 (15,1,1) = {"
 XU
 XU
-Rm
+wo
 jh
 aw
-Lr
+Gy
 aw
 JF
 kE
-QS
+Ds
 ea
+TT
 Cb
-og
-sZ
+xS
 Gv
 PU
 na
@@ -5988,11 +5987,11 @@ vp
 ZN
 vo
 Hp
-zb
-MQ
-Uu
+FG
+Ok
+tc
 qa
-mL
+it
 qa
 qf
 XU
@@ -6004,7 +6003,7 @@ XU
 (16,1,1) = {"
 XU
 XU
-Rm
+wo
 jh
 vN
 vN
@@ -6019,9 +6018,9 @@ yG
 RG
 RG
 RG
-DM
-wy
-ML
+qe
+Nz
+fx
 RG
 RG
 Hq
@@ -6046,7 +6045,7 @@ Mp
 vT
 wY
 Hp
-zb
+FG
 aC
 aB
 qa
@@ -6062,7 +6061,7 @@ XU
 (17,1,1) = {"
 XU
 XU
-Rm
+wo
 jh
 aw
 TB
@@ -6070,16 +6069,16 @@ VM
 Jn
 Rv
 vW
-Aa
-Aa
-Sh
+zv
+zv
+lv
 Rv
 vj
 ut
 fq
-wo
-wo
-wo
+zb
+zb
+zb
 AK
 NP
 Sr
@@ -6087,9 +6086,9 @@ qj
 pr
 af
 ok
-TA
-TA
-TA
+Vr
+Vr
+Vr
 NY
 iy
 Ju
@@ -6104,9 +6103,9 @@ vp
 QB
 vo
 Hp
-zb
-MQ
-tc
+FG
+Ok
+Kt
 qa
 gu
 qa
@@ -6120,27 +6119,27 @@ XU
 (18,1,1) = {"
 XU
 XU
-Rm
+wo
 jh
 aw
 Xb
-ww
+Ym
 Qq
-OP
+SX
 UE
 qC
-mr
-fS
+Cd
 xx
+fI
 mv
 OV
 uY
-gD
-gD
+cm
+cm
 ES
 fD
 Cn
-Iq
+pE
 kU
 yB
 Ir
@@ -6151,7 +6150,7 @@ xM
 Im
 yj
 jS
-yO
+TJ
 gX
 td
 HF
@@ -6159,10 +6158,10 @@ Is
 tr
 ae
 sB
-cP
-Ym
+rN
+EW
 xh
-FG
+jU
 aC
 AM
 sw
@@ -6178,18 +6177,18 @@ XU
 (19,1,1) = {"
 XU
 XU
-YH
+dr
 ap
 Mj
 aw
 aw
 iq
-tV
-tV
-tV
-tV
-Qn
-tV
+MO
+MO
+MO
+MO
+CR
+MO
 ip
 wj
 mJ
@@ -6203,9 +6202,9 @@ gB
 Di
 sf
 BG
-wi
+KT
 Xm
-JG
+wi
 TM
 jT
 HD
@@ -6218,7 +6217,7 @@ dI
 XS
 sB
 JV
-Ym
+EW
 xh
 ER
 Hh
@@ -6242,14 +6241,14 @@ Bq
 Os
 aw
 JU
-ln
+ps
 Sc
 nO
 oP
-qe
+ln
 RC
 Lk
-le
+rn
 Lk
 BR
 Lk
@@ -6281,7 +6280,7 @@ xh
 js
 OU
 fb
-zv
+eq
 qf
 lU
 XU
@@ -6299,12 +6298,12 @@ Dp
 hw
 dj
 Lq
-XR
+wt
 oR
-XR
-XR
-XR
-qe
+wt
+wt
+wt
+ln
 sM
 yG
 Lk
@@ -6326,14 +6325,14 @@ XU
 GD
 pO
 cj
-ps
+fZ
 eY
-Vr
+gD
 mo
 rW
-Vr
-ZY
-MO
+gD
+uf
+MQ
 FC
 va
 gy
@@ -6357,7 +6356,7 @@ XU
 hw
 hw
 Dp
-XR
+wt
 zF
 Xp
 oK
@@ -6383,7 +6382,7 @@ XU
 XU
 XU
 sn
-HV
+fs
 WJ
 WJ
 WJ
@@ -6397,7 +6396,7 @@ aG
 HB
 jg
 Aw
-eq
+XX
 qf
 lU
 XU
@@ -6415,12 +6414,12 @@ XU
 XU
 XU
 hw
-XR
-dn
+wt
 Fb
+TQ
 KE
-XR
-qv
+wt
+YW
 ug
 yG
 aX
@@ -6473,11 +6472,11 @@ XU
 XU
 XU
 XU
-Qr
-XR
-PF
-XR
-XR
+pY
+wt
+wW
+wt
+wt
 ki
 yG
 ja
@@ -6508,10 +6507,10 @@ SO
 Yd
 If
 kf
-cg
+Ld
 lq
 nn
-gY
+bT
 Ml
 ao
 AZ
@@ -6567,10 +6566,10 @@ Ph
 If
 WK
 Gf
-fZ
-fZ
+cg
+cg
 Ch
-fZ
+cg
 md
 IN
 qA
@@ -6632,7 +6631,7 @@ qq
 qq
 Hd
 mI
-PS
+nI
 PK
 cc
 oy
@@ -6791,8 +6790,8 @@ XU
 XU
 te
 ZD
-Kt
-Kt
+ww
+ww
 RE
 UC
 lg
@@ -6855,12 +6854,12 @@ mE
 qy
 Vl
 If
-CR
+TA
 vS
 PW
 Qu
+SP
 iS
-Ds
 PK
 kJ
 sH

--- a/_maps/voidcrew/ship_pill.dmm
+++ b/_maps/voidcrew/ship_pill.dmm
@@ -1,10 +1,10 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/obj/machinery/power/shuttle_engine/electric{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 4
+	},
+/obj/machinery/power/shuttle_engine/ship/electric{
 	dir = 4
 	},
 /turf/open/floor/carpet/neon/simple/red,
@@ -46,7 +46,6 @@
 /obj/item/storage/bag/ore,
 /obj/item/storage/bag/ore,
 /obj/item/weldingtool/experimental,
-/obj/item/clothing/head/welding,
 /obj/item/areaeditor,
 /obj/item/clothing/suit/hooded/carp_costume/spaceproof/old,
 /obj/item/clothing/suit/hooded/carp_costume/spaceproof/old,
@@ -88,6 +87,7 @@
 /obj/item/storage/toolbox/mechanical/old,
 /obj/item/storage/box/stockparts/basic,
 /obj/item/circuitboard/machine/autolathe,
+/obj/item/clothing/head/utility/welding,
 /turf/open/floor/carpet/neon/simple/red,
 /area/station/commons/storage/primary)
 

--- a/_maps/voidcrew/ship_pill_black.dmm
+++ b/_maps/voidcrew/ship_pill_black.dmm
@@ -1,8 +1,5 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/obj/machinery/power/shuttle_engine/electric{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 4
@@ -11,6 +8,9 @@
 	minimum_timer = 180;
 	name = "Alternative Bluespace Jump Device";
 	timer_set = 180
+	},
+/obj/machinery/power/shuttle_engine/ship/electric{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/primary)

--- a/_maps/voidcrew/ship_pubby.dmm
+++ b/_maps/voidcrew/ship_pubby.dmm
@@ -565,7 +565,7 @@
 /turf/open/floor/engine,
 /area/station/cargo/warehouse)
 "yt" = (
-/obj/machinery/power/shuttle_engine/fueled/plasma{
+/obj/machinery/power/shuttle_engine/ship/fueled/plasma{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -777,7 +777,7 @@
 /turf/open/floor/engine,
 /area/station/cargo/warehouse)
 "Ls" = (
-/obj/machinery/power/shuttle_engine/electric{
+/obj/machinery/power/shuttle_engine/ship/electric{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -820,7 +820,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/mineral/equipment_vendor,
+/obj/machinery/computer/order_console/mining,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "No" = (

--- a/_maps/voidcrew/ship_spitfire.dmm
+++ b/_maps/voidcrew/ship_spitfire.dmm
@@ -383,8 +383,8 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery)
 "rj" = (
-/obj/machinery/power/shuttle_engine/liquid/oil,
 /obj/structure/window/reinforced/survival_pod,
+/obj/machinery/power/shuttle_engine/ship/liquid/oil,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "rA" = (
@@ -980,8 +980,8 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/office)
 "SE" = (
-/obj/machinery/power/shuttle_engine/liquid/oil,
 /obj/structure/window/reinforced/survival_pod,
+/obj/machinery/power/shuttle_engine/ship/liquid/oil,
 /turf/open/floor/plating,
 /area/station/cargo/office)
 "SI" = (

--- a/_maps/voidcrew/ship_syndicate_blackbeard.dmm
+++ b/_maps/voidcrew/ship_syndicate_blackbeard.dmm
@@ -37,10 +37,10 @@
 /obj/item/gun/ballistic/rocketlauncher/unrestricted,
 /obj/item/ammo_casing/caseless/rocket,
 /obj/item/ammo_casing/caseless/rocket,
-/obj/item/ammo_casing/caseless/rocket/hedp,
 /obj/structure/railing{
 	dir = 10
 	},
+/obj/item/ammo_casing/caseless/rocket/heap,
 /turf/open/floor/mineral/plastitanium,
 /area/station/cargo)
 "bl" = (
@@ -133,12 +133,12 @@
 /turf/open/floor/mineral/plastitanium,
 /area/station/command/bridge)
 "fy" = (
-/obj/machinery/power/shuttle_engine/electric{
+/obj/structure/cable,
+/obj/machinery/power/shuttle_engine/ship/electric{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/external)
+/area/station/engineering)
 "fR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/layer4{
 	dir = 1
@@ -247,11 +247,11 @@
 /turf/open/floor/catwalk_floor,
 /area/station/command/bridge)
 "lZ" = (
-/obj/machinery/power/shuttle_engine/fueled/plasma{
+/obj/machinery/power/shuttle_engine/ship/fueled/plasma{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/external)
+/area/station/engineering)
 "mg" = (
 /obj/machinery/atmospherics/components/unary/passive_vent/layer2{
 	dir = 4

--- a/_maps/voidcrew/ship_syndicate_geneva.dmm
+++ b/_maps/voidcrew/ship_syndicate_geneva.dmm
@@ -55,14 +55,6 @@
 /obj/machinery/ore_silo,
 /turf/open/floor/carpet/neon/simple/red,
 /area/station/command/bridge)
-"bK" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "spitfireshutters"
-	},
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/station/service/hydroponics)
 "ca" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -401,12 +393,10 @@
 /area/station/engineering/main)
 "lm" = (
 /obj/effect/spawner/structure/window,
-/obj/structure/grille,
 /turf/open/floor/plating,
 /area/station/medical/surgery)
 "lr" = (
 /obj/effect/spawner/structure/window,
-/obj/structure/grille,
 /turf/open/floor/plating,
 /area/station/service/hydroponics)
 "lV" = (
@@ -439,7 +429,6 @@
 /turf/open/floor/carpet/neon/simple/red,
 /area/station/commons/dorms)
 "mX" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/docking_port/mobile/voidcrew{
 	can_move_docking_ports = 1;
 	dir = 2;
@@ -448,7 +437,7 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "spitfireshutters"
 	},
-/obj/structure/grille,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/command/bridge)
 "nc" = (
@@ -457,11 +446,10 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)
 "nd" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "spitfireshutters"
 	},
-/obj/structure/grille,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/cmo)
 "nf" = (
@@ -1020,11 +1008,10 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port)
 "Ao" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "spitfireshutters"
 	},
-/obj/structure/grille,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "Au" = (
@@ -1048,11 +1035,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/circuit,
 /area/station/engineering/main)
-"AW" = (
-/obj/structure/grille,
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/station/medical/surgery)
 "AX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1112,12 +1094,10 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "Cu" = (
-/obj/structure/grille,
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "Cz" = (
-/obj/structure/grille,
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
@@ -1138,7 +1118,6 @@
 	id = "spitfireshutters"
 	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/grille,
 /turf/open/floor/plating,
 /area/station/service/hydroponics)
 "Da" = (
@@ -1166,20 +1145,20 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port)
 "Dl" = (
-/obj/machinery/power/shuttle_engine/liquid/oil,
 /obj/structure/window/reinforced/survival_pod,
 /obj/machinery/door/poddoor/preopen{
 	id = "spitfireshutters"
 	},
+/obj/machinery/power/shuttle_engine/ship/liquid/oil,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "Dm" = (
-/obj/machinery/power/shuttle_engine/liquid/oil,
 /obj/structure/window/reinforced/survival_pod,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/poddoor/preopen{
 	id = "spitfireshutters"
 	},
+/obj/machinery/power/shuttle_engine/ship/liquid/oil,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "Dt" = (
@@ -1252,11 +1231,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "Ge" = (
-/obj/machinery/power/shuttle_engine/liquid/oil,
 /obj/structure/window/reinforced/survival_pod,
 /obj/machinery/door/poddoor/preopen{
 	id = "spitfireshutters"
 	},
+/obj/machinery/power/shuttle_engine/ship/liquid/oil,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "Gn" = (
@@ -1336,11 +1315,10 @@
 /turf/open/floor/plating,
 /area/station/cargo/miningoffice)
 "Hi" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "spitfireshutters"
 	},
-/obj/structure/grille,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/medical/surgery)
 "HS" = (
@@ -1378,7 +1356,6 @@
 /area/station/command/bridge)
 "ME" = (
 /obj/effect/spawner/structure/window,
-/obj/structure/grille,
 /turf/open/floor/plating,
 /area/station/commons/dorms)
 "QH" = (
@@ -1386,7 +1363,6 @@
 /area/station/cargo/miningoffice)
 "Sc" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/grille,
 /turf/open/floor/plating,
 /area/station/command/bridge)
 "SE" = (
@@ -1397,19 +1373,17 @@
 /turf/open/floor/carpet/neon/simple/red,
 /area/station/commons/dorms)
 "SR" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "spitfireshutters"
 	},
-/obj/structure/grille,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/commons/dorms)
 "Ux" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "spitfireshutters"
 	},
-/obj/structure/grille,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/command/bridge)
 "Vn" = (
@@ -1649,7 +1623,7 @@ ZB
 ZB
 ZB
 ZB
-bK
+CO
 cE
 dh
 el
@@ -1700,7 +1674,7 @@ aJ
 ss
 YX
 In
-AW
+lm
 In
 In
 In

--- a/_maps/voidcrew/ship_syndicate_hyena.dmm
+++ b/_maps/voidcrew/ship_syndicate_hyena.dmm
@@ -16,8 +16,8 @@
 "bd" = (
 /obj/effect/turf_decal/bot_white,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/circuitboard/machine/mining_equipment_vendor,
 /obj/structure/closet/crate,
+/obj/item/circuitboard/computer/order_console/mining,
 /turf/open/floor/iron/dark,
 /area/station/cargo)
 "bl" = (
@@ -307,12 +307,12 @@
 /obj/item/clothing/shoes/jackboots,
 /obj/item/clothing/gloves/combat,
 /obj/item/clothing/glasses/thermal/eyepatch,
-/obj/item/clothing/head/hos/syndicate,
 /obj/item/gun/ballistic/revolver,
 /obj/item/ammo_box/a357/match,
 /obj/item/pen/edagger,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/secure_closet/hos,
+/obj/item/clothing/head/hats/hos/syndicate,
 /turf/open/floor/carpet/black,
 /area/station/command/bridge)
 "hy" = (
@@ -727,10 +727,10 @@
 /obj/item/storage/belt/utility,
 /obj/item/clothing/glasses/meson,
 /obj/item/clothing/glasses/welding,
-/obj/item/clothing/head/hardhat,
 /obj/item/clothing/head/soft/yellow,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/item/clothing/head/utility/hardhat,
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/primary)
 "rM" = (
@@ -831,7 +831,6 @@
 /obj/item/storage/belt/mining,
 /obj/item/clothing/glasses/meson,
 /obj/item/clothing/glasses/welding,
-/obj/item/clothing/head/hardhat/orange,
 /obj/item/clothing/head/soft/grey,
 /obj/machinery/light/small{
 	dir = 1
@@ -843,6 +842,7 @@
 	},
 /obj/item/gps/mining,
 /obj/machinery/airalarm/directional/north,
+/obj/item/clothing/head/utility/hardhat/orange,
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/primary)
 "tI" = (
@@ -1114,7 +1114,6 @@
 /obj/item/storage/belt/mining,
 /obj/item/clothing/glasses/meson,
 /obj/item/clothing/glasses/welding,
-/obj/item/clothing/head/hardhat/orange,
 /obj/item/clothing/head/soft/grey,
 /obj/item/storage/box/emptysandbags,
 /obj/item/kinetic_crusher{
@@ -1122,6 +1121,7 @@
 	pixel_y = 6
 	},
 /obj/item/gps/mining,
+/obj/item/clothing/head/utility/hardhat/orange,
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/primary)
 "zZ" = (
@@ -1265,7 +1265,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine/hull,
-/area/station/external)
+/area/station/commons/storage/primary)
 "DF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1604,6 +1604,10 @@
 /obj/structure/weightmachine/weightlifter,
 /turf/open/floor/iron/dark,
 /area/station/commons)
+"Li" = (
+/obj/structure/lattice,
+/turf/template_noop,
+/area/station/maintenance/starboard)
 "Lj" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Port Thrusters"
@@ -1672,10 +1676,10 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo)
 "MF" = (
-/obj/machinery/power/shuttle_engine/electric{
+/obj/structure/cable,
+/obj/machinery/power/shuttle_engine/ship/electric{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "MO" = (
@@ -1806,11 +1810,12 @@
 /turf/open/floor/mineral/plastitanium,
 /area/station/ai_monitored/security/armory)
 "PL" = (
-/obj/structure/window/reinforced/spawner/west,
-/obj/machinery/door/poddoor{
-	id = "wrecker_engine_port"
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 4
 	},
-/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/plasma/spawner/north,
+/obj/structure/window/reinforced/plasma/spawner/east,
+/obj/structure/window/reinforced/plasma/spawner,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "PT" = (
@@ -1944,7 +1949,7 @@
 /turf/open/floor/plating,
 /area/station/command/bridge)
 "TT" = (
-/obj/machinery/power/shuttle_engine/fueled/plasma{
+/obj/machinery/power/shuttle_engine/ship/fueled/plasma{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -1955,10 +1960,10 @@
 /turf/open/floor/iron/white,
 /area/station/cargo)
 "Ua" = (
-/obj/machinery/power/shuttle_engine/electric{
+/obj/structure/cable,
+/obj/machinery/power/shuttle_engine/ship/electric{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "Uh" = (
@@ -2020,7 +2025,7 @@
 /area/station/maintenance/fore)
 "VG" = (
 /turf/open/floor/engine/hull,
-/area/station/external)
+/area/station/commons/storage/primary)
 "VQ" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/bot_white,
@@ -2054,7 +2059,6 @@
 /obj/item/storage/belt/utility/chief,
 /obj/item/clothing/glasses/meson,
 /obj/item/clothing/glasses/welding,
-/obj/item/clothing/head/hardhat/white,
 /obj/item/storage/toolbox/syndicate,
 /obj/item/wrench/combat,
 /obj/item/ammo_box/magazine/m10mm/ap,
@@ -2134,7 +2138,7 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/office)
 "Xz" = (
-/obj/machinery/power/shuttle_engine/fueled/plasma{
+/obj/machinery/power/shuttle_engine/ship/fueled/plasma{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -2217,7 +2221,7 @@
 "Zb" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/station/external)
+/area/station/hallway/primary/central)
 "Zg" = (
 /obj/effect/turf_decal/stripes{
 	dir = 1
@@ -2434,7 +2438,7 @@ jf
 Fe
 GV
 CW
-Zb
+Li
 "}
 (10,1,1) = {"
 Zb
@@ -2454,7 +2458,7 @@ Ay
 AP
 GV
 nn
-Zb
+Li
 "}
 (11,1,1) = {"
 Zb
@@ -2474,7 +2478,7 @@ Sd
 dQ
 Sg
 nn
-Zb
+Li
 "}
 (12,1,1) = {"
 Zb
@@ -2494,7 +2498,7 @@ Az
 pv
 GV
 nn
-Zb
+Li
 "}
 (13,1,1) = {"
 Zb
@@ -2513,8 +2517,8 @@ MR
 zq
 Iz
 GV
-Zb
-Zb
+Li
+Li
 "}
 (14,1,1) = {"
 Zb
@@ -2534,7 +2538,7 @@ GV
 GV
 GV
 nn
-Zb
+Li
 "}
 (15,1,1) = {"
 Zb
@@ -2554,7 +2558,7 @@ KW
 VY
 QW
 nn
-Zb
+Li
 "}
 (16,1,1) = {"
 Rn
@@ -2574,7 +2578,7 @@ Bg
 jY
 yn
 oO
-Zb
+Li
 "}
 (17,1,1) = {"
 cs

--- a/voidcrew/mapping/shuttles/osprey.dm
+++ b/voidcrew/mapping/shuttles/osprey.dm
@@ -72,3 +72,111 @@
 			slots = 5,
 		),
 	)
+
+/// DOCKING PORT ///
+
+/obj/docking_port/mobile/voidcrew/osprey
+	name = "Osprey-Class Exploration Ship"
+	area_type = /area/shuttle/voidcrew/osprey
+	callTime = 25 SECONDS
+	dir = 4
+	port_direction = 8
+	preferred_direction = 4
+
+
+/// AREAS ///
+
+/// Engineering ///
+/area/shuttle/voidcrew/osprey/engineering
+	name = "Engineering"
+	icon_state = "engine"
+
+/area/shuttle/voidcrew/osprey/engineering/atmospherics
+	name = "Atmospherics"
+	icon_state = "atmos"
+
+/// Research ///
+
+/area/shuttle/voidcrew/osprey/research
+	name = "Research"
+	icon_state = "research"
+
+/area/shuttle/voidcrew/osprey/research/robotics
+	name = "Robotics"
+	icon_state = "robotics"
+
+/// Cargo ///
+
+/area/shuttle/voidcrew/osprey/cargo
+	name = "Cargo Office"
+	icon_state = "cargo_office"
+
+/area/shuttle/voidcrew/osprey/cargo/warehouse
+	name = "Warehouse"
+	icon_state = "cargo_warehouse"
+
+/area/shuttle/voidcrew/osprey/cargo/quartermaster
+	name = "Quartermaster's Office"
+	icon_state = "qm_office"
+
+/area/shuttle/voidcrew/osprey/cargo/mining_dock
+	name = "Mining Dock"
+	icon_state = "mining_dock"
+
+/// Medbay ///
+
+/area/shuttle/voidcrew/osprey/medbay
+	name = "Medbay"
+	icon_state = "medbay"
+
+/area/shuttle/voidcrew/osprey/medbay/lobby
+	name = "Medbay Lobby"
+	icon_state = "med_lobby"
+
+/// Service ///
+
+/area/shuttle/voidcrew/osprey/service/cafeteria
+	name = "Cafeteria"
+	icon_state = "cafeteria"
+
+/area/shuttle/voidcrew/osprey/service/janitor
+	name = "Custodial Closet"
+	icon_state = "janitor"
+
+/area/shuttle/voidcrew/osprey/service/dormitories
+	name = "Dormitories"
+	icon_state = "dorms"
+
+/// Command ///
+
+/area/shuttle/voidcrew/osprey/bridge
+	name = "Bridge"
+	icon_state = "bridge"
+
+/// Hallways ///
+
+/area/shuttle/voidcrew/osprey/hallway/central
+	name = "Central Hallway"
+	icon_state = "centralhall"
+
+/area/shuttle/voidcrew/osprey/hallway/aft
+	name = "Aft Hallway"
+	icon_state = "afthall"
+
+/area/shuttle/voidcrew/osprey/hallway/port
+	name = "Port Hallway"
+	icon_state = "porthall"
+
+/area/shuttle/voidcrew/osprey/hallway/starboard
+	name = "Starboard Hallway"
+	icon_state = "starboardhall"
+
+/// Maintenance ///
+
+/area/shuttle/voidcrew/osprey/maintenance/port
+	name = "Port Maintenance"
+	icon_state = "portmaint"
+
+/area/shuttle/voidcrew/osprey/maintenance/starboard
+	name = "Starboard Maintenance"
+	icon_state = "starboardmaint"


### PR DESCRIPTION
## About The Pull Request

<details>
<summary>The Osprey Stuff:</summary>

Tunes up the Osprey with modern /tg/ fixtures, in the style of previous tuneups of mine. 
~~I am not being held against my will to work on random Nanotrasen projects, what, no, that'd be crazy.~~
New Osprey:
![2022 12 01-22 47 13](https://user-images.githubusercontent.com/50649185/205210805-a811d99c-2d1e-4309-b188-5539a09d8b1c.png)

Gameplay changes are as follows:
The QM now has an office, which comes with it's own APC and power drain,
Science has a space to actually make use of their RND boards without tearing stuff down, which cargo shares without having to walk inside,
One set of 30 plasma sheets has been exchanged for an (empty) superpacman. No uranium spawns on the ship,
Battery loopback has been OBLITERATED,
Janitor has a bunch of extra dust to clean up,
Some differently-layered wires for the engineers to scratch their heads at exist now,
All those goofy-ass firelock-under-doors are gone. Smartfirelocks + Airlocks do not mix.

</details>

<details>
<summary>The Missing Path Stuff:</summary>

Fixes missing paths on EVERY shuttle in the voidcrew folder and replaces as many windows as I noticed with their spawner counterparts. `Kill. Maim. Slaughter.`
Fixes up the wiring on one specific one, muses on some wacky tobacky stuff I unearthed (See the first commit's description!)

</details>

## Why It's Good For The Game
Contributes to #18
## Changelog
:cl:
add: The Osprey has been tuned up!
fix: All missing paths have been addressed (by hand, not by an updatepaths script.)
/:cl:
