### PR TITLE
removes firelocks / fixes windows

### DIFF
--- a/_maps/voidcrew/ship_box.dmm
+++ b/_maps/voidcrew/ship_box.dmm
@@ -24,9 +24,8 @@
 "ah" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /obj/machinery/door/poddoor{
-	id = "whiteship_windows"
+	id = "whiteship_bridge"
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/voidcrew/box/medbay)
 "aj" = (
@@ -38,9 +37,8 @@
 "ak" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /obj/machinery/door/poddoor{
-	id = "whiteship_windows"
+	id = "whiteship_bridge"
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/voidcrew/box/cargo)
 "am" = (
@@ -1361,9 +1359,6 @@
 /area/shuttle/voidcrew/box/medbay)
 "LG" = (
 /obj/structure/table/glass,
-/obj/machinery/computer/med_data/laptop{
-	density = 0
-	},
 /obj/machinery/door/window/left/directional/north,
 /turf/open/floor/iron/dark,
 /area/shuttle/voidcrew/box/crew_quarters)
@@ -1426,9 +1421,8 @@
 "Rx" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /obj/machinery/door/poddoor{
-	id = "whiteship_windows"
+	id = "whiteship_bridge"
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/voidcrew/box/crew_quarters)
 "SJ" = (
@@ -1437,14 +1431,6 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/voidcrew/box/crew_quarters)
-"TB" = (
-/obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor{
-	id = "whiteship_bridge"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/shuttle/voidcrew/box/bridge)
 "Uc" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -2052,11 +2038,11 @@ aa
 aa
 aa
 bf
-TB
+bf
 bK
 cb
 co
-TB
+bf
 bf
 aa
 aa
@@ -2071,11 +2057,11 @@ aa
 aa
 aa
 aa
-TB
-TB
-TB
-TB
-TB
+bf
+bf
+bf
+bf
+bf
 aa
 aa
 aa

--- a/_maps/voidcrew/ship_delta.dmm
+++ b/_maps/voidcrew/ship_delta.dmm
@@ -17,7 +17,6 @@
 /obj/machinery/door/poddoor{
 	id = "whiteship_windows"
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/voidcrew/delta/dorms)
 "ae" = (
@@ -37,7 +36,6 @@
 /obj/machinery/door/poddoor{
 	id = "whiteship_windows"
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/voidcrew/delta/cafe)
 "ah" = (
@@ -800,7 +798,6 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/gun/ballistic/shotgun,
-/obj/item/gun/ballistic/revolver/detective,
 /obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/iron/dark,
 /area/shuttle/voidcrew/delta/cafe)
@@ -1061,7 +1058,6 @@
 /obj/machinery/door/poddoor{
 	id = "whiteship_windows"
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/voidcrew/delta/airlock/port)
 "cu" = (
@@ -1903,7 +1899,6 @@
 /obj/machinery/door/poddoor{
 	id = "whiteship_windows"
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/voidcrew/delta/hallway/central)
 "pb" = (
@@ -2068,7 +2063,6 @@
 /obj/machinery/door/poddoor{
 	id = "whiteship_windows"
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/voidcrew/delta/cargo)
 "HJ" = (
@@ -2105,7 +2099,6 @@
 /obj/machinery/door/poddoor{
 	id = "whiteship_windows"
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/voidcrew/delta/medbay)
 "Nf" = (

--- a/_maps/voidcrew/ship_kilo.dmm
+++ b/_maps/voidcrew/ship_kilo.dmm
@@ -54,13 +54,6 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/blood/old,
-/mob/living/simple_animal/hostile/netherworld/migo{
-	environment_smash = 0;
-	faction = list("neutral");
-	melee_damage_lower = 5;
-	melee_damage_upper = 10;
-	name = "maurice"
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/voidcrew/kilo/cargo/mining_dock)
@@ -275,10 +268,9 @@
 "bP" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /obj/machinery/door/poddoor{
-	id = "whiteship_bridge";
-	name = "Cockpit Emergency Blas Door"
+	id = "whiteship_windows";
+	name = "Exterior Window Blas Door"
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/voidcrew/kilo/bridge)
 "bQ" = (
@@ -514,8 +506,6 @@
 	id = "whiteship_windows";
 	name = "Exterior Window Blas Door"
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/shuttle/voidcrew/kilo/cargo)
 "cV" = (
@@ -554,6 +544,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/mob/living/basic/migo{
+	faction = list("neutral");
+	name = "timothy";
+	desc = "A pinkish, fungoid crustacean-like creature with numerous pairs of clawed appendages and a head covered with waving antennae. He looks friendly."
+	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/voidcrew/kilo/bridge)
 "cZ" = (
@@ -647,7 +642,6 @@
 	id = "whiteship_windows";
 	name = "Exterior Window Blas Door"
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/voidcrew/kilo/cafe)
 "eo" = (
@@ -705,7 +699,6 @@
 	id = "whiteship_windows";
 	name = "Exterior Window Blas Door"
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/voidcrew/kilo/dorms)
 "gn" = (
@@ -1245,14 +1238,6 @@
 /obj/item/bedsheet/captain,
 /turf/open/floor/wood,
 /area/shuttle/voidcrew/kilo/dorms)
-"Bu" = (
-/obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor{
-	id = "whiteship_bridge";
-	name = "Cockpit Emergency Blas Door"
-	},
-/turf/open/floor/plating,
-/area/shuttle/voidcrew/kilo/bridge)
 "BZ" = (
 /obj/structure/table,
 /obj/machinery/button/door{
@@ -1477,7 +1462,6 @@
 	id = "whiteship_windows";
 	name = "Exterior Window Blas Door"
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/voidcrew/kilo/engineering)
 "LC" = (
@@ -1501,7 +1485,6 @@
 	id = "whiteship_windows";
 	name = "Exterior Window Blas Door"
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/voidcrew/kilo/cargo/mining_dock)
 "Mj" = (
@@ -1944,7 +1927,7 @@ Jf
 bP
 Jf
 bP
-Bu
+bP
 aa
 aa
 "}
@@ -1960,7 +1943,7 @@ ng
 gC
 oj
 bP
-Bu
+bP
 aa
 "}
 (4,1,1) = {"
@@ -1976,7 +1959,7 @@ hh
 oP
 BZ
 bP
-Bu
+bP
 "}
 (5,1,1) = {"
 aa

--- a/_maps/voidcrew/ship_libertatia.dmm
+++ b/_maps/voidcrew/ship_libertatia.dmm
@@ -96,9 +96,7 @@
 	},
 /obj/item/storage/belt/sabre,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/item/gun/ballistic/revolver/detective{
-	name = "captain's revolver"
-	},
+/obj/item/gun/ballistic/revolver/c38,
 /turf/open/floor/pod/light,
 /area/shuttle/voidcrew/libertatia/bridge)
 "ci" = (
@@ -386,6 +384,7 @@
 /obj/item/knife/hunting{
 	pixel_y = -5
 	},
+/obj/structure/table/reinforced,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/voidcrew/libertatia/armory)
 "pU" = (
@@ -641,7 +640,6 @@
 	pixel_y = 30
 	},
 /obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/item/clothing/gloves/color/latex,
 /obj/item/clothing/mask/surgical,
 /obj/item/clothing/suit/apron/surgical,
 /obj/structure/sign/departments/medbay/alt/directional/west,

--- a/_maps/voidcrew/ship_luxembourg.dmm
+++ b/_maps/voidcrew/ship_luxembourg.dmm
@@ -108,7 +108,6 @@
 /obj/item/clothing/suit/armor/vest/capcarapace/syndicate,
 /obj/item/storage/box/syndie_kit/chameleon,
 /obj/item/card/id/advanced/black/syndicate_command,
-/obj/item/clothing/head/hos/beret/syndicate,
 /obj/item/card/emag,
 /obj/item/storage/belt/sabre,
 /obj/item/gun/energy/recharge/kinetic_accelerator,
@@ -535,7 +534,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/item/clothing/head/hos/beret/syndicate,
 /obj/item/card/id/advanced/black/syndicate_command,
 /obj/item/clothing/under/syndicate,
 /obj/item/clothing/under/syndicate/skirt,
@@ -543,8 +541,10 @@
 /obj/item/gun/ballistic/shotgun/doublebarrel,
 /obj/item/storage/box/syndie_kit/chameleon,
 /obj/structure/closet/secure_closet/bar{
-	req_access = list(25,41)
+	req_access = null;
+	req_one_access = list(25,41)
 	},
+/obj/item/clothing/head/beret,
 /turf/open/floor/plating,
 /area/shuttle/voidcrew/luxembourg/engineering)
 "na" = (
@@ -572,7 +572,6 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/voidcrew/luxembourg/bridge)
 "nx" = (
-/obj/item/clothing/head/hos/beret/syndicate,
 /obj/item/card/id/advanced/black/syndicate_command,
 /obj/item/clothing/under/syndicate/skirt,
 /obj/item/clothing/under/syndicate/bloodred/sleepytime,
@@ -772,7 +771,6 @@
 /obj/item/card/id/advanced/black/syndicate_command,
 /obj/item/clothing/under/syndicate/skirt,
 /obj/item/clothing/under/syndicate/bloodred/sleepytime,
-/obj/item/clothing/head/hos/beret/syndicate,
 /obj/item/wrench/combat,
 /obj/item/pipe_dispenser,
 /obj/item/clothing/under/syndicate,
@@ -1180,7 +1178,6 @@
 /obj/item/card/id/advanced/black/syndicate_command,
 /obj/item/clothing/under/syndicate/skirt,
 /obj/item/clothing/under/syndicate/bloodred/sleepytime,
-/obj/item/clothing/head/hos/beret/syndicate,
 /obj/item/toy/figure/cargotech,
 /obj/item/clothing/head/beret/cargo,
 /obj/item/clothing/suit/hooded/wintercoat/cargo,
@@ -1198,7 +1195,6 @@
 /obj/item/card/id/advanced/black/syndicate_command,
 /obj/item/clothing/under/syndicate/skirt,
 /obj/item/clothing/under/syndicate/bloodred/sleepytime,
-/obj/item/clothing/head/hos/beret/syndicate,
 /obj/item/toy/figure/cargotech,
 /obj/item/clothing/head/beret/cargo,
 /obj/item/clothing/suit/hooded/wintercoat/cargo,
@@ -1514,9 +1510,6 @@
 /obj/item/clothing/under/syndicate,
 /obj/item/clothing/under/syndicate,
 /obj/item/clothing/under/syndicate,
-/obj/item/clothing/head/hos/beret/syndicate,
-/obj/item/clothing/head/hos/beret/syndicate,
-/obj/item/clothing/head/hos/beret/syndicate,
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/carpet/donk,
 /area/shuttle/voidcrew/luxembourg/dormitories)

--- a/_maps/voidcrew/ship_nano_phalanx.dmm
+++ b/_maps/voidcrew/ship_nano_phalanx.dmm
@@ -17,7 +17,7 @@
 /area/shuttle/voidcrew/phalanx/cargo)
 "ap" = (
 /obj/machinery/door/poddoor{
-	id = "phpublicblastdoors"
+	id = "phbridgeblastdoors"
 	},
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
@@ -1123,8 +1123,7 @@
 /turf/open/floor/mineral/titanium/tiled/blue,
 /area/shuttle/voidcrew/phalanx/medbay)
 "pg" = (
-/obj/structure/window/reinforced/shuttle,
-/obj/structure/grille,
+/obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/mineral/titanium/tiled/blue,
 /area/shuttle/voidcrew/phalanx/medbay)
 "pl" = (
@@ -1419,11 +1418,10 @@
 /turf/open/floor/iron,
 /area/shuttle/voidcrew/phalanx/hallway/central)
 "tn" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/shuttle,
 /obj/machinery/door/poddoor{
 	id = "phbridgeblastdoors"
 	},
+/obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/voidcrew/phalanx/bridge)
 "tz" = (
@@ -1536,12 +1534,6 @@
 "uE" = (
 /turf/open/floor/engine/n2,
 /area/shuttle/voidcrew/phalanx/engineering/atmospherics)
-"uF" = (
-/obj/machinery/computer/med_data{
-	dir = 1
-	},
-/turf/open/floor/carpet/executive,
-/area/shuttle/voidcrew/phalanx/bridge)
 "uM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1765,11 +1757,10 @@
 /turf/open/floor/iron,
 /area/shuttle/voidcrew/phalanx/hallway/aft)
 "yk" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/shuttle,
 /obj/machinery/door/poddoor{
-	id = "phpublicblastdoors"
+	id = "phbridgeblastdoors"
 	},
+/obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/voidcrew/phalanx/cafeteria)
 "yo" = (
@@ -2778,8 +2769,7 @@
 /turf/open/floor/iron,
 /area/shuttle/voidcrew/phalanx/cargo/mining)
 "NC" = (
-/obj/structure/window/reinforced/shuttle,
-/obj/structure/grille,
+/obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/mineral/titanium/tiled/purple,
 /area/shuttle/voidcrew/phalanx/nanites)
 "NE" = (
@@ -5248,7 +5238,7 @@ GW
 Ae
 oa
 zD
-uF
+GW
 tn
 oZ
 oZ

--- a/_maps/voidcrew/ship_pubby.dmm
+++ b/_maps/voidcrew/ship_pubby.dmm
@@ -115,14 +115,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/engine,
 /area/shuttle/voidcrew/pubby/cargo)
-"fh" = (
-/obj/machinery/door/poddoor{
-	id = "whiteship_bridge"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/spawner/structure/window/reinforced/shuttle,
-/turf/open/floor/plating,
-/area/shuttle/voidcrew/pubby/bridge)
 "gr" = (
 /obj/machinery/door/airlock/titanium/glass,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -208,14 +200,6 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/voidcrew/pubby/cargo)
-"iZ" = (
-/obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/poddoor{
-	id = "whiteship_bridge"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/shuttle/voidcrew/pubby/bridge)
 "jJ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -1492,14 +1476,14 @@ qx
 (24,1,1) = {"
 qx
 qx
-iZ
+Xc
 Xc
 TG
 JU
 hw
 iJ
 Xc
-iZ
+Xc
 qx
 qx
 "}
@@ -1507,12 +1491,12 @@ qx
 qx
 qx
 qx
-iZ
-iZ
-iZ
-fh
-fh
-iZ
+Xc
+Xc
+Xc
+Xc
+Xc
+Xc
 qx
 qx
 qx


### PR DESCRIPTION

## About The Pull Request

Some ships were spawning with firelocks on the outside windows of the ship, causing issues due to being right next to a vacuum. Some other ships were not using window spawners. Both of these issues have been fixed.

## Why It's Good For The Game

Having firelocks enabled when there are no atmospheric issues inside the ship is usually a bad thing.

## Changelog

:cl:
del: Removed firelocks where needed
/:cl:
